### PR TITLE
Major Renderer and Scene changes.

### DIFF
--- a/assets/default.material
+++ b/assets/default.material
@@ -1,3 +1,8 @@
 # Material
-shader: "assets/default.shader",
-  diffuse: "assets/smol.texture"
+@material:
+  queue: 10,
+  shader: "assets/default.shader"
+  color: {1, 1, 1, .8},
+  mainTex: 0
+
+@texture: diffuse: "assets/smol.texture"

--- a/assets/default.shader
+++ b/assets/default.shader
@@ -6,11 +6,13 @@ vertexShader:"
   layout (location = 3) in vec3 normalIn;
 
   uniform mat4 proj;
+  uniform vec4 color;
+
   out vec4 vertColor; 
   out vec2 uv;
   void main() {
     gl_Position = proj * vec4(vertPos, 1.0);
-    vertColor = colorIn;
+    vertColor = colorIn * color;
     uv = vertUVIn;
 }
 ",

--- a/assets/grass.material
+++ b/assets/grass.material
@@ -1,0 +1,10 @@
+# Material
+@material:
+  queue: 20,
+  shader: "assets/default.shader",
+  color: {.2, 1, .3, 1},
+  mainTex: 0 # index of the texture to use. This is a SAMPLER_2D uniform
+
+
+@texture: diffuse: "assets/grass_03.texture"
+

--- a/assets/grass_03.texture
+++ b/assets/grass_03.texture
@@ -1,0 +1,6 @@
+#Wrap:    REPEAT = 0, REPEAT_MIRRORED = 1, CLAMP_TO_EDGE = 2
+#Filter:  LINEAR = 0, NEAREST = 1
+#Mipmap:  LINEAR_MIPMAP_LINEAR = 0, LINEAR_MIPMAP_NEAREST = 1, NEAREST_MIPMAP_LINEAR = 2, NEAREST_MIPMAP_NEAREST = 3, NO_MIPMAP = 4
+
+@texture: image: "assets/grass_03.bmp", wrap: 2, filter: 1, mipmap: 2
+

--- a/assets/smol.texture
+++ b/assets/smol.texture
@@ -2,5 +2,5 @@
 #Filter:  LINEAR = 0, NEAREST = 1
 #Mipmap:  LINEAR_MIPMAP_LINEAR = 0, LINEAR_MIPMAP_NEAREST = 1, NEAREST_MIPMAP_LINEAR = 2, NEAREST_MIPMAP_NEAREST = 3, NO_MIPMAP = 4
 
-image: "assets/smol32.bmp", wrap: 0, filter: 0, mipmap: 0
+@texture: image: "assets/smol32.bmp", wrap: 2, filter: 1, mipmap: 1
 

--- a/src/demo/game.cpp
+++ b/src/demo/game.cpp
@@ -22,7 +22,7 @@ int shape = 0;
 
 void onStart(smol::SystemsRoot* systemsRoot)
 {
-  srand(time(0));
+  srand((uint32) time(0));
   smol::Log::info("Game started!");
   root = systemsRoot;
   smol::Scene& scene = root->loadedScene;

--- a/src/include/smol/smol_renderer_types.h
+++ b/src/include/smol/smol_renderer_types.h
@@ -87,7 +87,7 @@ namespace smol
     GLuint location;
   };
 
-  struct MaterialParameter : public ShaderParameter
+  struct SMOL_ENGINE_API MaterialParameter : public ShaderParameter
   {
     union
     {

--- a/src/include/smol/smol_scene.h
+++ b/src/include/smol/smol_scene.h
@@ -23,7 +23,7 @@ namespace smol
     Handle<Renderable> renderable;
   };
 
-  struct SpriteSceneNode
+  struct SpriteSceneNode : public MeshSceneNode
   {
     Handle<SpriteBatcher> batcher;
     Rect rect;
@@ -127,8 +127,9 @@ namespace smol
 
    
     Handle<Material> loadMaterial(const char* path);
-    Handle<Material> createMaterial(Handle<ShaderProgram> shader, Handle<Texture>* diffuseTextures, int diffuseTextureCount);
+    Handle<Material> createMaterial(Handle<ShaderProgram> shader, Handle<Texture>* diffuseTextures, int diffuseTextureCount, int renderQueue = (int) RenderQueue::QUEUE_OPAQUE);
     void destroyMaterial(Handle<Material> handle);
+    Material* getMaterial(Handle<Material> handle);
 
     Handle<Mesh> createMesh(bool dynamic, const MeshData& meshData);
     Handle<Mesh> createMesh(bool dynamic,

--- a/src/smol_renderer_gl.cpp
+++ b/src/smol_renderer_gl.cpp
@@ -925,14 +925,12 @@ namespace smol
           break;
 
         default:
-
-          if (!node->isActiveInHierarchy())
-          {
-            discard = true;
-          }
+          discard = true;
           break;
       }
 
+      if (!discard && !node->isActiveInHierarchy())
+        discard = true;
 
       if (!renderable)
         discard = true;
@@ -1000,7 +998,7 @@ namespace smol
           switch(parameter.type)
           {
             case ShaderParameter::SAMPLER_2D:
-              if (parameter.uintValue < material->diffuseTextureCount)
+              if (parameter.uintValue < (uint32) material->diffuseTextureCount)
               {
                 int textureIndex = parameter.uintValue;
                 Handle<Texture> hTexture = material->textureDiffuse[textureIndex];

--- a/src/smol_renderer_gl.cpp
+++ b/src/smol_renderer_gl.cpp
@@ -464,6 +464,8 @@ namespace smol
   void Renderer::destroyShaderProgram(ShaderProgram* program)
   {
     glDeleteProgram(program->programId);
+    program->programId = -1;
+    program->valid = false;
   }
 
   //
@@ -833,6 +835,7 @@ namespace smol
         currentMaterial = material;
         shader = scene.shaders.lookup(material->shader);
         if(shader)
+        if(shader && shader->valid)
         {
           // use WHITE as default color for vertex attribute when using a valid shader
           shaderProgramId = shader->programId;

--- a/src/smol_renderer_gl.cpp
+++ b/src/smol_renderer_gl.cpp
@@ -334,6 +334,7 @@ namespace smol
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     }
 
+    glBindTexture(GL_TEXTURE_2D, 0);
     return outTexture->textureObject != 0;
   }
 

--- a/src/smol_scene.cpp
+++ b/src/smol_scene.cpp
@@ -264,7 +264,7 @@ namespace smol
           {
             // The sampler_2d is an index for the material's texture list
             uint32 textureIndex = (uint32) materialEntry->getVariableNumber(param.name);
-            if (textureIndex >= numDiffuseTextures)
+            if (textureIndex >= (uint32) numDiffuseTextures)
             {
               Log::error("Material parameter '%s' references an out of bounds texture index %d",
                   param.name, textureIndex);
@@ -334,7 +334,7 @@ namespace smol
         // for robustness, if the parameter is a texture and there are textures, we try to assing them as they apper
         if (materialParam.type == ShaderParameter::SAMPLER_2D && diffuseTextureCount)
         {
-          if (texturesAssigned >= diffuseTextureCount)
+          if (texturesAssigned >= (uint32) diffuseTextureCount)
             texturesAssigned = 0;
 
           materialParam.uintValue = texturesAssigned++;


### PR DESCRIPTION
- Scene::loadTexture looks for a "T@exture" entry
- Scene::createTexture() now accepts wrap, filter and mipmap settings as optional parameters
- Scene::createMaterial() looks for shader uniforms and stores their location, type and name.
- Scene::loadMaterial() looks for a "@Material" entry
- Scene::loadMaterial() will look for entries that matches shader uniform locations and will store the values in the material for passing to the renderer
- Added Scene::getMaterial()
- Added Material::setUint(), Material::setInt(), Material::setFloat(), Material::setVec2, Material::setVec3(), Material::setVec4() and Material::setSampler2D() for setting material/shader propertyes
- Changed SpriteSceneNode to inherit from MeshSceneNode so both nodes share a Handle<Renderable>
- Changed Scene::createSpritNode() so it coppies the SpriteBatcher::renderable handle to the SceneNode::renderable. This redundancy is intended to simplify the renderer and avoid fetching handles when not necessary.
- Updated assets/default.material file sytax
- Updated assets/smol.texture file sytax
- Updated assets/default.shader: added a color uniform
- Updated demo/game.cpp to use the apis changed on this commit. The game uses materials manually created with Scene::createMaterial() and file based material loaded with Scene::loadMaterial(). Also, for the manually created materials it sets some uniforms with the new Material::setxxx() methods.