### PR TITLE
Feature/bmp text

### DIFF
--- a/assets/default.material
+++ b/assets/default.material
@@ -1,10 +1,10 @@
 # Material
 #depthTest:  DISABLE = 0, LESS = 1, LESS_EQUAL = 2, EQUAL = 3, GREATER = 4, GREATER_EQUAL = 5, DIFFERENT = 6, NEVER = 7, ALWAYS = 8
-#cullFace: BACK = 0, FRONT = 1, FRONT_AND_BACK = 2, NONE = 3
+#cullFace: NONE = 0, BACK = 1, FRONT = 2, FRONT_AND_BACK  = 3
 @material:
   queue: 10,
   depthTest: 2,
-  cullFace: 0,
+  cullFace: 1,
   shader: "assets/default.shader",
   color: {1, 1, 0, 1},
   mainTex: "assets/smol.texture"

--- a/assets/font.material
+++ b/assets/font.material
@@ -1,6 +1,6 @@
 # Material
 #depthTest:  DISABLE = 0, LESS = 1, LESS_EQUAL = 2, EQUAL = 3, GREATER = 4, GREATER_EQUAL = 5, DIFFERENT = 6, NEVER = 7, ALWAYS = 8
-#cullFace: BACK = 0, FRONT = 1, FRONT_AND_BACK = 2, NONE = 3
+#cullFace: NONE = 0, BACK = 1, FRONT = 2, FRONT_AND_BACK  = 3
 @material:
   queue: 10,
   depthTest: 2,

--- a/assets/grass_02.material
+++ b/assets/grass_02.material
@@ -1,10 +1,10 @@
 # Material
 #depthTest:  DISABLE = 0, LESS = 1, LESS_EQUAL = 2, EQUAL = 3, GREATER = 4, GREATER_EQUAL = 5, DIFFERENT = 6, NEVER = 7, ALWAYS = 8
-#cullFace: BACK = 0, FRONT = 1, FRONT_AND_BACK = 2, NONE = 3
+#cullFace: NONE = 0, BACK = 1, FRONT = 2, FRONT_AND_BACK  = 3
 @material:
   queue: 11,
   depthTest: 1,
-  cullFace: 3,
+  cullFace: 0,
   shader: "assets/default.shader",
   color: {0.675, 0.729, 0.224, 1.0},
   mainTex: "assets/grass_02.texture"

--- a/assets/grass_03.material
+++ b/assets/grass_03.material
@@ -1,10 +1,10 @@
 # Material
 #depthTest:  DISABLE = 0, LESS = 1, LESS_EQUAL = 2, EQUAL = 3, GREATER = 4, GREATER_EQUAL = 5, DIFFERENT = 6, NEVER = 7, ALWAYS = 8
-#cullFace: BACK = 0, FRONT = 1, FRONT_AND_BACK = 2, NONE = 3
+#cullFace: NONE = 0, BACK = 1, FRONT = 2, FRONT_AND_BACK  = 3
 @material:
   queue: 11,
   depthTest: 1,
-  cullFace: 3,
+  cullFace: 0,
   shader: "assets/default.shader",
   color: {0.6509, 0.41960, 0.26666, 1.0},
   mainTex: "assets/grass_03.texture"

--- a/assets/sdf.shader
+++ b/assets/sdf.shader
@@ -31,8 +31,8 @@ fragmentShader:"
   in vec4 vertColor;
   in vec2 uv;
 
-  const float width = 0.45;
-  const float edge = 0.2;
+  const float width = 0.38;
+  const float edge = 0.10;
 
   void main()
   {

--- a/assets/variables.txt
+++ b/assets/variables.txt
@@ -3,7 +3,7 @@
 @system:
   show_cursor: 1,
   capture_cursor: 0,
-  gl_version: {3, 1}
+  gl_version: {3, 3}
 
 @renderer:
   enable_gamma_correction: 1,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ list(APPEND srcs
   ${SOURCE_PATH}/smol_random.cpp
   ${SOURCE_PATH}/include/smol/smol_point.h
   ${SOURCE_PATH}/include/smol/smol_renderer_types.h
+  ${SOURCE_PATH}/include/smol/smol_stream_buffer.h
   ${SOURCE_PATH}/include/smol/smol_mesh.h
   ${SOURCE_PATH}/include/smol/smol_sprite_batcher.h
   ${SOURCE_PATH}/smol_sprite_batcher.cpp
@@ -60,6 +61,7 @@ list(APPEND srcs
   ${SOURCE_PATH}/include/smol/smol_texture.h
   ${SOURCE_PATH}/include/smol/smol_material.h
   ${SOURCE_PATH}/include/smol/smol_font.h
+  ${SOURCE_PATH}/smol_font.cpp
   ${SOURCE_PATH}/smol_material.cpp
   ${SOURCE_PATH}/include/smol/smol_handle_list.h
   ${SOURCE_PATH}/include/smol/smol_systems_root.h
@@ -96,8 +98,15 @@ list(APPEND srcs
   ${SOURCE_PATH}/include/smol/smol_camera.h
   ${SOURCE_PATH}/smol_camera.cpp
   ${SOURCE_PATH}/smol_renderer_gl.cpp
-  ${SOURCE_PATH}/include/smol/smol_scene_nodes.h
-  ${SOURCE_PATH}/smol_scene_nodes.cpp
+  ${SOURCE_PATH}/include/smol/smol_scene_node_common.h
+  ${SOURCE_PATH}/include/smol/smol_scene_node.h
+  ${SOURCE_PATH}/smol_scene_node.cpp
+  ${SOURCE_PATH}/include/smol/smol_text_node.h
+  ${SOURCE_PATH}/smol_text_node.cpp
+  ${SOURCE_PATH}/include/smol/smol_sprite_node.h
+  ${SOURCE_PATH}/smol_sprite_node.cpp
+  ${SOURCE_PATH}/include/smol/smol_mesh_node.h
+  ${SOURCE_PATH}/smol_mesh_node.cpp
   ${SOURCE_PATH}/include/smol/smol_scene.h
   ${SOURCE_PATH}/smol_scene.cpp
   ${SOURCE_PATH}/include/smol/smol_cfg_parser.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,8 @@ list(APPEND srcs
   ${SOURCE_PATH}/smol_scene_node.cpp
   ${SOURCE_PATH}/include/smol/smol_text_node.h
   ${SOURCE_PATH}/smol_text_node.cpp
+  ${SOURCE_PATH}/include/smol/smol_camera_node.h
+  ${SOURCE_PATH}/smol_camera_node.cpp
   ${SOURCE_PATH}/include/smol/smol_sprite_node.h
   ${SOURCE_PATH}/smol_sprite_node.cpp
   ${SOURCE_PATH}/include/smol/smol_mesh_node.h

--- a/src/demo/game.cpp
+++ b/src/demo/game.cpp
@@ -179,15 +179,14 @@ void onStart()
       p, smol::Color::BLUE);
 
   smol::SpriteNode::create(textBatcher,
-      smol::Rect(339, 479, 32, 32), // FOLDER
-      //smol::Rect(378, 507, 409, 481), SMOL LOGO
-      //smol::Rect(270, 476, 32, 32), // CUBE
-      //smol::Rect(303, 476, 32, 32), // DOCUMENT
+      //smol::Rect(339, 479, 32, 32), // FOLDER
+      // smol::Rect(270, 476, 32, 32), // CUBE
+      smol::Rect(304, 476, 32, 32), // DOCUMENT
       smol::Transform()
-      .setPosition(0.0f, 1.0f, 0.0f)
+      .setPosition(-1.0f, 1.0f, 0.0f)
       .setParent(node1),
       .32f, .32f,
-      smol::Color::YELLOW);
+      smol::Color::WHITE);
 
   selectedNode = cameraNode;
 }

--- a/src/demo/game.cpp
+++ b/src/demo/game.cpp
@@ -5,6 +5,7 @@
 #include <smol/smol_cfg_parser.h>
 #include <smol/smol_font.h>
 #include <smol/smol_sprite_node.h>
+#include <smol/smol_camera_node.h>
 #include <utility>
 #include <time.h>
 
@@ -168,14 +169,14 @@ void onStart()
 
   // camera
   smol::Transform t;
-  cameraNode = scene.createPerspectiveCameraNode(60.0f, 0.01f, 3000.0f, t);
+  cameraNode = smol::CameraNode::createPerspective(60.0f, 0.01f, 3000.0f, t);
 
   cameraNode->transform
     .setRotation(0.0f, .0f, 0.0f)
     .setPosition(0.0f, 0.0f, 0.5f);
   cameraNode->camera.setLayerMask((uint32)(smol::Layer::LAYER_0 | smol::Layer::LAYER_1 | smol::Layer::LAYER_2));
 
-  sideCamera = scene.createPerspectiveCameraNode(60.0f, 0.01f, 3000.0f, t);
+  sideCamera = smol::CameraNode::createPerspective(60.0f, 0.01f, 3000.0f, t);
   sideCamera->transform
     .setRotation(-30.0f, 0.0f, 0.0f)
     .setPosition(0.0f, 10.0f, 15.0f);
@@ -239,8 +240,9 @@ void onStart()
 
   textBatcher = scene.createSpriteBatcher(fontMaterial, smol::SpriteBatcher::SCREEN);
 
-  char* p = "Hello, Sailor!\nI'm a lumberjack and I'm ok!";
+  const char* p = "Hello, Sailor!\nI'm a lumberjack and I'm ok!";
   drawString(p, font, -5.0f, 3.0f, textBatcher, scene, smol::Color::BLACK);
+  smol::TextNode::create(textBatcher, font, smol::Vector3(-5.0f, 3.0f, 0.3f), p);
 
   smol::SpriteNode::create(textBatcher,
       //smol::Rect(378, 507, 409, 481), SMOL LOGO

--- a/src/demo/game.cpp
+++ b/src/demo/game.cpp
@@ -9,7 +9,7 @@
 
 float drawGliph(smol::Glyph& g, float x, float y, 
     smol::Kerning* kernings, uint16 kerningCount,
-    smol::Handle<smol::SpriteBatcher> batcher, smol::Scene& scene)
+    smol::Handle<smol::SpriteBatcher> batcher, smol::Scene& scene, smol::Color color)
 {
   const float scale = 0.01f;
   const float width   = g.rect.w * scale;
@@ -35,13 +35,13 @@ float drawGliph(smol::Glyph& g, float x, float y,
   }
 
   scene.createSpriteNode(batcher, g.rect,
-      smol::Vector3(x + xOffset + kerning, y, 0.3f),
-      width, height);
+      smol::Vector3(x + xOffset + kerning, y, 0.0f),
+      width, height, color);
 
   return x + xAdvance + kerning;
 }
 
-void drawString(const char* str, smol::Font* font, float x, float y, smol::Handle<smol::SpriteBatcher> batcher, smol::Scene& scene)
+void drawString(const char* str, smol::Font* font, float x, float y, smol::Handle<smol::SpriteBatcher> batcher, smol::Scene& scene, smol::Color color)
 {
   float advance = x;
   smol::Kerning* kerning = nullptr;
@@ -61,7 +61,7 @@ void drawString(const char* str, smol::Font* font, float x, float y, smol::Handl
           y -= font->lineHeight / 100.0f;
           advance = x;
         }
-        advance = drawGliph(glyph, advance, y, kerning, kerningCount, batcher, scene);
+        advance = drawGliph(glyph, advance, y, kerning, kerningCount, batcher, scene, color);
         // kerning information for the next character
         kerning = &font->kerning[glyph.kerningStart];
         kerningCount = glyph.kerningCount;
@@ -232,16 +232,16 @@ void onStart()
   textBatcher = scene.createSpriteBatcher(fontMaterial, smol::SpriteBatcher::SCREEN);
 
   char* p = "Testing string drawing!\nThis is another text line :)";
-  drawString(p, font, -5.0f, 0.0f, textBatcher, scene);
+  drawString(p, font, -5.0f, 0.0f, textBatcher, scene, smol::Color::BLUE);
 
   scene.createSpriteNode(textBatcher,
       //smol::Rect(378, 507, 409, 481), SMOL LOGO
-      //smol::Rect(339, 479, 32, 32), // FOLDER
+      smol::Rect(339, 479, 32, 32), // FOLDER
       //smol::Rect(270, 476, 32, 32), // CUBE
-      smol::Rect(303, 476, 32, 32), // DOCUMENT
+      //smol::Rect(303, 476, 32, 32), // DOCUMENT
       smol::Vector3(0.0f, 3.0f, 0.3f),
       0.32f, 0.32f,
-      smol::Color::WHITE);
+      smol::Color::YELLOW);
 
   selectedNode = cameraNode;
 }

--- a/src/include/smol/smol_camera.h
+++ b/src/include/smol/smol_camera.h
@@ -76,17 +76,18 @@ namespace smol
     float right;
     float left;
     float bottom;
-    float orthographicSize;
-    Rectf rect;
     Type type;
+    float orthographicSize;
+    uint32 clearOperation;
+    uint32 priority;
     uint32 layers;
-    Mat4 viewMatrix;
-    unsigned int clearOperation;
+    Rectf rect;
     Color clearColor;
-    unsigned int priority;
+    Mat4 viewMatrix;
 
     public:
-    Camera(Type type, float sizeOrFov, float zNear, float zFar);
+    Camera();
+    //Camera(Type type, float sizeOrFov, float zNear, float zFar);
 
     Camera& setPerspective(float fov, float zNear, float zFar);
     Camera& setOrthographic(float size, float zNear, float zFar);
@@ -115,7 +116,6 @@ namespace smol
     float getOrthographicSize() const;
     float getOrthographicWidth() const;
     void update();
-
   };
 }
 #endif  // SMOL_CAMERA_H

--- a/src/include/smol/smol_camera_node.h
+++ b/src/include/smol/smol_camera_node.h
@@ -1,0 +1,22 @@
+#ifndef SMOL_CAMERA_NODE_H
+#define SMOL_CAMERA_NODE_H
+#include <smol/smol_camera.h>
+#include <smol/smol_handle_list.h>
+
+namespace smol
+{
+  struct SceneNode;
+  class Transform;
+
+  struct SMOL_ENGINE_API CameraNode final : public Camera
+  {
+    static Handle<SceneNode> createPerspective(float fov, float zNear, float zFar, Transform& transform);
+    static Handle<SceneNode> createOrthographic(float size, float zNear, float zFar, Transform& transform);
+    static void destroy(Handle<SceneNode> handle);
+
+    private:
+    CameraNode();
+  };
+}
+#endif //SMOL_CAMERA_NODE_H
+

--- a/src/include/smol/smol_color.h
+++ b/src/include/smol/smol_color.h
@@ -25,6 +25,7 @@ namespace smol
 
     float r, g, b, a;
 
+    Color();
     Color(int r, int g, int b, int a = 255);
     Color(float r, float g, float b, float a = 1.0f);
     Color(const Color& other);

--- a/src/include/smol/smol_font.h
+++ b/src/include/smol/smol_font.h
@@ -1,4 +1,6 @@
 #include <smol/smol_handle_list.h>
+#include <smol/smol_texture.h>
+#include <smol/smol_rect.h>
 #include <smol/smol.h>
 
 #ifndef SMOL_FONT_H
@@ -24,7 +26,7 @@ namespace smol
     Rect rect;
   };
 
-  struct SMOL_ENGINE_API Font
+  struct SMOL_ENGINE_API FontInfo
   {
     uint16 size;
     uint16 lineHeight;
@@ -36,6 +38,32 @@ namespace smol
     const char* name;
     Handle<Texture> texture;
   };
+
+  // Because Fonts have a variable size, the Font asset acts as a wrapper around
+  // the dynamically allocated FontInfo.
+  struct SMOL_ENGINE_API Font
+  {
+    private:
+    const FontInfo* fontInfo;
+
+    public:
+    Font(FontInfo* info);
+    Handle<Texture> getTexture() const;
+    const char* getName() const;
+    uint16 getSize() const;
+    uint16 getBase() const;
+    uint16 getLineHeight() const;
+    uint16 getKerningCount() const;
+    uint16 getGlyphCount() const;
+    const Kerning* getKernings(int* count = nullptr) const; 
+    const Glyph* getGlyphs(int* count = nullptr) const; 
+#ifndef SMOL_MODULE_GAME
+    const FontInfo* getFontInfo() const;
+#endif
+  };
+
+  template class SMOL_ENGINE_API smol::HandleList<smol::Font>;
+  template class SMOL_ENGINE_API smol::Handle<smol::Font>;
 }
 
 #endif  // SMOL_FONT_H

--- a/src/include/smol/smol_material.h
+++ b/src/include/smol/smol_material.h
@@ -47,10 +47,10 @@ namespace smol
 
     enum CullFace
     {
-      BACK            = 0,
-      FRONT           = 1,
-      FRONT_AND_BACK  = 2,
-      NONE            = 3
+      NONE            = 0,
+      BACK            = 1,
+      FRONT           = 2,
+      FRONT_AND_BACK  = 3
     };
 
     char name[MAX_NAME_LEN];

--- a/src/include/smol/smol_mesh.h
+++ b/src/include/smol/smol_mesh.h
@@ -1,13 +1,15 @@
 #ifndef SMOL_MESH_H
 #define SMOL_MESH_H
 
+#include <smol/smol_engine.h>
+#include <smol/smol_handle_list.h>
+
 #define SMOL_GL_DEFINE_EXTERN
 #include <smol/smol_gl.h> //TODO(marcio): Make this API independent. Remove all GL specifics from this header
 #undef SMOL_GL_DEFINE_EXTERN
 
 namespace smol
 {
-
   struct SMOL_ENGINE_API Mesh final
   {
     enum

--- a/src/include/smol/smol_mesh_node.h
+++ b/src/include/smol/smol_mesh_node.h
@@ -1,0 +1,21 @@
+#ifndef SMOL_MESH_NODE_H
+#define SMOL_MESH_NODE_H
+
+#include <smol/smol_scene_node_common.h>
+#include <smol/smol_handle_list.h>
+#include <smol/smol_transform.h>
+
+namespace smol
+{
+  struct Renderable;
+
+  struct SMOL_ENGINE_API MeshNode final : public NodeComponent
+  {
+    Handle<Renderable> renderable;
+
+    static Handle<SceneNode> create(Handle<Renderable> renderable, Transform& transform);
+    static void destroy(Handle<SceneNode> handle);
+  };
+}
+#endif //SMOL_MESH_NODE_H
+

--- a/src/include/smol/smol_renderer.h
+++ b/src/include/smol/smol_renderer.h
@@ -2,7 +2,7 @@
 #define SMOL_RENDERER_H
 
 #include <smol/smol_engine.h>
-#include <smol/smol_renderer_types.h>
+#include <smol/smol_stream_buffer.h>
 
 namespace smol
 {
@@ -16,6 +16,10 @@ namespace smol
   struct ConfigEntry;
   struct GlobalRendererConfig;
 
+  //
+  // A stream buffer is an interleaved buffer meant to be overwritten frequently
+  //
+  struct StreamBuffer;
   class SMOL_ENGINE_API Renderer
   {
     Scene* scene;
@@ -79,6 +83,22 @@ namespace smol
 
     static void updateMesh(Mesh* mesh, MeshData* meshData);
     static void destroyMesh(Mesh* mesh);
+
+    //
+    // StreamBuffers
+    //
+
+    static bool createStreamBuffer(StreamBuffer* out, uint32 capacity = 8, StreamBuffer::Format format = StreamBuffer::POS_COLOR_UV, uint32 indicesPerElement = 6);
+    static bool resizeStreamBuffer(StreamBuffer& streamBuffer, uint32 capacity);
+    static void bindStreamBuffer(StreamBuffer& streamBuffer);
+    static void unbindStreamBuffer(StreamBuffer& streamBuffer);
+    static bool destroyStreamBuffer(StreamBuffer& streamBuffer);
+
+    static void begin(StreamBuffer& streamBuffer);
+    static void pushSprite(StreamBuffer& streamBuffer, const Vector3& position, const Vector2& size, const Rectf& uv, const Color& color);
+    static void pushSprite(StreamBuffer& streamBuffer, const Vector3& position, const Vector2& size, const Rectf& uv, const Color& tlColor, const Color& trColor, const Color& blColor, const Color& brColor);
+    static void end(StreamBuffer& streamBuffer);
+    static void flush(StreamBuffer& streamBuffer);
   };
 }
 #endif  // SMOL_RENDERER_H

--- a/src/include/smol/smol_renderer_types.h
+++ b/src/include/smol/smol_renderer_types.h
@@ -13,7 +13,6 @@
 #include <smol/smol_shader.h>
 #include <smol/smol_texture.h>
 #include <smol/smol_mesh_data.h>
-#include <smol/smol_sprite_batcher.h>
 #include <smol/smol_mesh.h>
 #include <smol/smol_renderable.h>
 

--- a/src/include/smol/smol_renderer_types.h
+++ b/src/include/smol/smol_renderer_types.h
@@ -35,6 +35,16 @@ namespace smol
     LINE,
     POINT
   };
+
+#pragma pack(push, 1)
+  struct VertexPCU
+  {
+    Vector3 position;
+    Color color;
+    Vector2 uv;
+  };
+#pragma pack(pop)
+
 }
 
 #endif  // SMOL_RENDERER_TYPES_H

--- a/src/include/smol/smol_resource_manager.h
+++ b/src/include/smol/smol_resource_manager.h
@@ -10,11 +10,6 @@ namespace smol
 {
   struct Mesh;
 
-  template class SMOL_ENGINE_API smol::HandleList<smol::Mesh>;
-  template class SMOL_ENGINE_API smol::HandleList<smol::Texture>;
-  template class SMOL_ENGINE_API smol::HandleList<smol::Material>;
-  template class SMOL_ENGINE_API smol::HandleList<smol::ShaderProgram>;
-
   struct SMOL_ENGINE_API Image
   {
     enum PixelFormat16
@@ -37,6 +32,7 @@ namespace smol
       HandleList<ShaderProgram> shaders;
       smol::HandleList<smol::Material> materials;
       HandleList<smol::Mesh> meshes;
+      HandleList<Font> fonts;
       ShaderProgram* defaultShader;
       Handle<Texture> defaultTextureHandle; 
       Texture* defaultTexture;
@@ -149,9 +145,9 @@ namespace smol
 
 
       // Font
-      Font* loadFont(const char* fileName);
+      Handle<Font> loadFont(const char* fileName);
 
-      void unloadFont(const Font* fontInfo);
+      void unloadFont(Handle<Font> handle);
 
   };
 }

--- a/src/include/smol/smol_scene.h
+++ b/src/include/smol/smol_scene.h
@@ -31,7 +31,6 @@ namespace smol
     Handle<smol::ShaderProgram> defaultShader;
     Handle<smol::Material> defaultMaterial;
     Mat4 viewMatrix;
-    Handle<SceneNode> mainCamera;
     const smol::SceneNode nullSceneNode;
 
     Scene();
@@ -60,8 +59,6 @@ namespace smol
     Handle<SceneNode> createNode(SceneNode::Type type, Transform& transform);
     void destroyNode(Handle<SceneNode> handle);
 #endif
-
-    void setMainCamera(Handle<SceneNode> handle);
 
     //
     // misc

--- a/src/include/smol/smol_scene.h
+++ b/src/include/smol/smol_scene.h
@@ -72,7 +72,6 @@ namespace smol
 
     void destroyNode(Handle<SceneNode> handle);
     void destroyNode(SceneNode* node);
-    Handle<SceneNode> clone(Handle<SceneNode> handle);
 
     void setMainCamera(Handle<SceneNode> handle);
 

--- a/src/include/smol/smol_scene.h
+++ b/src/include/smol/smol_scene.h
@@ -11,6 +11,7 @@
 #include <smol/smol_color.h>
 #include <smol/smol_scene_nodes.h>
 #include <smol/smol_systems_root.h>
+#include <smol/smol_sprite_batcher.h>
 
 namespace smol
 {

--- a/src/include/smol/smol_scene.h
+++ b/src/include/smol/smol_scene.h
@@ -61,10 +61,6 @@ namespace smol
     void destroyNode(Handle<SceneNode> handle);
 #endif
 
-    Handle<SceneNode> createPerspectiveCameraNode(float fov, float zNear, float zFar, const Transform& transform);
-    Handle<SceneNode> createOrthographicCameraNode(float size, float zNear, float zFar, const Transform& transform);
-
-
     void setMainCamera(Handle<SceneNode> handle);
 
     //

--- a/src/include/smol/smol_scene.h
+++ b/src/include/smol/smol_scene.h
@@ -9,7 +9,7 @@
 #include <smol/smol_mat4.h>
 #include <smol/smol_transform.h>
 #include <smol/smol_color.h>
-#include <smol/smol_scene_nodes.h>
+#include <smol/smol_scene_node.h>
 #include <smol/smol_systems_root.h>
 #include <smol/smol_sprite_batcher.h>
 
@@ -47,32 +47,23 @@ namespace smol
 
     Handle<SpriteBatcher> createSpriteBatcher(Handle<Material> material, SpriteBatcher::Mode mode = SpriteBatcher::SCREEN, int capacity = 32);
 
-  SpriteBatcher::Mode getSpriteBatcherMode(Handle<SpriteBatcher> handle) const;
+    SpriteBatcher::Mode getSpriteBatcherMode(Handle<SpriteBatcher> handle) const;
 
-  void setSpriteBatcherMode(Handle<SpriteBatcher> handle, SpriteBatcher::Mode mode);
-
-  void destroySpriteBatcher(Handle<SpriteBatcher> handle);
+    void setSpriteBatcherMode(Handle<SpriteBatcher> handle, SpriteBatcher::Mode mode);
+    void destroySpriteBatcher(Handle<SpriteBatcher> handle);
 
     //
     // Scene Node creation
     //
-    Handle<SceneNode> createMeshNode(Handle<Renderable> renderable, const Transform& transform = Transform());
-
-    Handle<SceneNode> createSpriteNode(
-        Handle<SpriteBatcher> batcher,
-        const Rect& rect,
-        const Vector3& position,
-        float width,
-        float height,
-        const Color& color = Color::WHITE,
-        int angle = 0,
-        Handle<SceneNode> parent = Scene::ROOT);
+   
+#ifndef SMOL_MODULE_GAME
+    Handle<SceneNode> createNode(SceneNode::Type type, Transform& transform);
+    void destroyNode(Handle<SceneNode> handle);
+#endif
 
     Handle<SceneNode> createPerspectiveCameraNode(float fov, float zNear, float zFar, const Transform& transform);
     Handle<SceneNode> createOrthographicCameraNode(float size, float zNear, float zFar, const Transform& transform);
 
-    void destroyNode(Handle<SceneNode> handle);
-    void destroyNode(SceneNode* node);
 
     void setMainCamera(Handle<SceneNode> handle);
 

--- a/src/include/smol/smol_scene.h
+++ b/src/include/smol/smol_scene.h
@@ -56,7 +56,7 @@ namespace smol
     //
    
 #ifndef SMOL_MODULE_GAME
-    Handle<SceneNode> createNode(SceneNode::Type type, Transform& transform);
+    Handle<SceneNode> createNode(SceneNode::Type type, const Transform& transform);
     void destroyNode(Handle<SceneNode> handle);
 #endif
 

--- a/src/include/smol/smol_scene_node.h
+++ b/src/include/smol/smol_scene_node.h
@@ -7,41 +7,17 @@
 #include <smol/smol_color.h>
 #include <smol/smol_renderer_types.h>
 #include <smol/smol_camera.h>
+#include <smol/smol_font.h>
+#include <smol/smol_text_node.h>
+#include <smol/smol_sprite_node.h>
+#include <smol/smol_mesh_node.h>
+#include <smol/smol_scene_node_common.h>
 
 namespace smol
 {
   struct Scene;
   struct Renderable;
   struct SpriteBatcher;
-
-  struct Sprite
-  {
-    Rect rect;
-    float width;
-    float height;
-    Color color;
-    int angle;
-    Sprite() : color(Color::WHITE){ }
-  };
-
-  struct MeshNodeInfo
-  {
-    Handle<Renderable> renderable;
-    virtual ~MeshNodeInfo();
-  };
-
-  struct SpriteNodeInfo final : public MeshNodeInfo
-  {
-    Handle<SpriteBatcher> batcher;
-    union 
-    {
-      Sprite sprite;
-      Arena arena;
-    };
-    int spriteCount;
-    SpriteNodeInfo();
-    ~SpriteNodeInfo() override;
-  };
 
   struct SMOL_ENGINE_API SceneNode final
   {
@@ -51,14 +27,16 @@ namespace smol
       ROOT = 0, // there must be only ONE root node in a scene
       CAMERA,
       MESH,
-      SPRITE
+      SPRITE,
+      TEXT
     };
 
     Transform transform;
     union
     {
-      MeshNodeInfo mesh;
-      SpriteNodeInfo spriteInfo;
+      MeshNode mesh;
+      SpriteNode sprite;
+      TextNode text;
       Camera camera;
     };
 
@@ -85,7 +63,6 @@ namespace smol
     void setParent(Handle<SceneNode> parent);
     void setLayer(Layer l);
   };
-
 
   template class SMOL_ENGINE_API smol::HandleList<smol::SceneNode>;
   template class SMOL_ENGINE_API smol::Handle<smol::SceneNode>;

--- a/src/include/smol/smol_scene_node.h
+++ b/src/include/smol/smol_scene_node.h
@@ -11,6 +11,7 @@
 #include <smol/smol_text_node.h>
 #include <smol/smol_sprite_node.h>
 #include <smol/smol_mesh_node.h>
+#include <smol/smol_camera_node.h>
 #include <smol/smol_scene_node_common.h>
 
 namespace smol
@@ -35,9 +36,9 @@ namespace smol
     union
     {
       MeshNode mesh;
-      SpriteNode sprite;
       TextNode text;
-      Camera camera;
+      SpriteNode sprite;
+      CameraNode camera;
     };
 
     private:

--- a/src/include/smol/smol_scene_node_common.h
+++ b/src/include/smol/smol_scene_node_common.h
@@ -1,0 +1,15 @@
+#ifndef SMOL_SCENE_NODE_COMMON_H
+#define SMOL_SCENE_NODE_COMMON_H
+
+#include <smol/smol_handle_list.h>
+namespace smol
+{
+  struct SceneNode;
+
+  struct NodeComponent
+  {
+    Handle<SceneNode> node;    // a reference to the node this component is attached to
+  };
+}
+#endif //SMOL_SCENE_NODE_COMMON_H
+

--- a/src/include/smol/smol_scene_nodes.h
+++ b/src/include/smol/smol_scene_nodes.h
@@ -14,6 +14,16 @@ namespace smol
   struct Renderable;
   struct SpriteBatcher;
 
+  struct Sprite
+  {
+    Rect rect;
+    float width;
+    float height;
+    Color color;
+    int angle;
+    Sprite() : color(Color::WHITE){ }
+  };
+
   struct MeshNodeInfo
   {
     Handle<Renderable> renderable;
@@ -22,14 +32,16 @@ namespace smol
   struct SpriteNodeInfo : public MeshNodeInfo
   {
     Handle<SpriteBatcher> batcher;
-    Rect rect;
-    float width;
-    float height;
-    Color color;
-    int angle;
+    union 
+    {
+      Sprite sprite;
+      Arena arena;
+    };
+    SpriteNodeInfo(): arena(0) {}
+    ~SpriteNodeInfo() {}
   };
 
-  struct SMOL_ENGINE_API SceneNode
+  struct SMOL_ENGINE_API SceneNode final
   {
     enum Type : char
     {
@@ -44,7 +56,7 @@ namespace smol
     union
     {
       MeshNodeInfo mesh;
-      SpriteNodeInfo sprite;
+      SpriteNodeInfo spriteInfo;
       Camera camera;
     };
 
@@ -57,6 +69,7 @@ namespace smol
 
     public:
     SceneNode();
+    ~SceneNode();
     SceneNode(Scene* scene, SceneNode::Type type, const Transform& transform = Transform());
     void setActive(bool status);
     void setDirty(bool value);

--- a/src/include/smol/smol_scene_nodes.h
+++ b/src/include/smol/smol_scene_nodes.h
@@ -27,9 +27,10 @@ namespace smol
   struct MeshNodeInfo
   {
     Handle<Renderable> renderable;
+    virtual ~MeshNodeInfo();
   };
 
-  struct SpriteNodeInfo : public MeshNodeInfo
+  struct SpriteNodeInfo final : public MeshNodeInfo
   {
     Handle<SpriteBatcher> batcher;
     union 
@@ -37,8 +38,9 @@ namespace smol
       Sprite sprite;
       Arena arena;
     };
-    SpriteNodeInfo(): arena(0) {}
-    ~SpriteNodeInfo() {}
+    int spriteCount;
+    SpriteNodeInfo();
+    ~SpriteNodeInfo() override;
   };
 
   struct SMOL_ENGINE_API SceneNode final

--- a/src/include/smol/smol_sprite_batcher.h
+++ b/src/include/smol/smol_sprite_batcher.h
@@ -4,9 +4,14 @@
 #include <smol/smol_engine.h>
 #include <smol/smol_renderable.h>
 #include <smol/smol_handle_list.h>
+#include <smol/smol_vector2.h>
+
 namespace smol
 {
   struct Scene;
+  struct Color;
+  struct SceneNode;
+
   struct SMOL_ENGINE_API SpriteBatcher final
   {
     enum Mode
@@ -18,9 +23,22 @@ namespace smol
     Mode mode;
     Handle<Renderable> renderable;
     Arena arena;
-    int spriteCount;
+    int nodeCount;        // how many nodes are handled by this sprite batcher
+    int spriteCount;      // how many sprites are handled by this batcher. Nodes can push multiple sprites
+    int batchedSprites;   // how many sprites are batched so far. Batches happen between begin() and end()
     int spriteCapacity;
-    bool dirty;
+  
+    //TODO(marcio): make these members private
+    Vector3*  positions;
+    bool      dirty;
+    char*     memory;
+    Color*    colors;
+    Vector2*  uvs;
+    uint32*   indices;
+
+    // we cache the texture dimentions to adjust sprite UVS
+    Vector2 textureDimention;
+
 
     static const size_t positionsSize;
     static const size_t indicesSize;
@@ -30,6 +48,11 @@ namespace smol
 
     SpriteBatcher(Handle<Material> material, Mode mode, int capacity);
     SpriteBatcher() = delete;
+    size_t getTotalSizeRequired() const;
+
+    void begin();
+    void pushSpriteNode(SceneNode* sceneNode);
+    void end();
   };
 
   template class SMOL_ENGINE_API smol::HandleList<smol::SpriteBatcher>;

--- a/src/include/smol/smol_sprite_batcher.h
+++ b/src/include/smol/smol_sprite_batcher.h
@@ -23,7 +23,8 @@ namespace smol
 
     Mode mode;
     Handle<Material> material;
-    int nodeCount;            // how many nodes are handled by this sprite batcher
+    int spriteNodeCount;
+    int textNodeCount;
     StreamBuffer buffer;
     bool      dirty;
 
@@ -36,6 +37,7 @@ namespace smol
 
     void begin();
     void pushSpriteNode(SceneNode* sceneNode);
+    void pushTextNode(SceneNode* sceneNode);
     void end();
   };
 

--- a/src/include/smol/smol_sprite_batcher.h
+++ b/src/include/smol/smol_sprite_batcher.h
@@ -5,6 +5,7 @@
 #include <smol/smol_renderable.h>
 #include <smol/smol_handle_list.h>
 #include <smol/smol_vector2.h>
+#include <smol/smol_stream_buffer.h>
 
 namespace smol
 {
@@ -21,34 +22,17 @@ namespace smol
     };
 
     Mode mode;
-    Handle<Renderable> renderable;
-    Arena arena;
-    int nodeCount;        // how many nodes are handled by this sprite batcher
-    int spriteCount;      // how many sprites are handled by this batcher. Nodes can push multiple sprites
-    int batchedSprites;   // how many sprites are batched so far. Batches happen between begin() and end()
-    int spriteCapacity;
-  
-    //TODO(marcio): make these members private
-    Vector3*  positions;
+    Handle<Material> material;
+    int nodeCount;            // how many nodes are handled by this sprite batcher
+    StreamBuffer buffer;
     bool      dirty;
-    char*     memory;
-    Color*    colors;
-    Vector2*  uvs;
-    uint32*   indices;
 
     // we cache the texture dimentions to adjust sprite UVS
     Vector2 textureDimention;
 
 
-    static const size_t positionsSize;
-    static const size_t indicesSize;
-    static const size_t colorsSize;
-    static const size_t uvsSize;
-    static const size_t totalSpriteSize;
-
     SpriteBatcher(Handle<Material> material, Mode mode, int capacity);
     SpriteBatcher() = delete;
-    size_t getTotalSizeRequired() const;
 
     void begin();
     void pushSpriteNode(SceneNode* sceneNode);

--- a/src/include/smol/smol_sprite_node.h
+++ b/src/include/smol/smol_sprite_node.h
@@ -1,0 +1,38 @@
+#ifndef SMOL_SPRITE_NODE_H
+#define SMOL_SPRITE_NODE_H
+
+#include <smol/smol_scene_node_common.h>
+#include <smol/smol_handle_list.h>
+#include <smol/smol_rect.h>
+#include <smol/smol_color.h>
+
+namespace smol
+{
+  struct SpriteBatcher;
+  struct Vector3;
+
+  struct SMOL_ENGINE_API SpriteNode final : public NodeComponent
+  {
+    Handle<SpriteBatcher> batcher;
+    Rect rect;
+    float width;
+    float height;
+    Color color;
+    int angle;
+
+  static Handle<SceneNode> create(
+      Handle<SpriteBatcher> batcher,
+      const Rect& rect,
+      const Vector3& position,
+      float width,
+      float height,
+      const Color& color,
+      int angle = 0,
+      Handle<SceneNode> parent = INVALID_HANDLE(SceneNode));
+
+  static void destroy(Handle<SceneNode> handle);
+
+  };
+}
+#endif //SMOL_SPRITE_NODE_H
+

--- a/src/include/smol/smol_sprite_node.h
+++ b/src/include/smol/smol_sprite_node.h
@@ -8,8 +8,9 @@
 
 namespace smol
 {
-  struct SpriteBatcher;
+  class Transform;
   struct Vector3;
+  struct SpriteBatcher;
 
   struct SMOL_ENGINE_API SpriteNode final : public NodeComponent
   {
@@ -18,17 +19,14 @@ namespace smol
     float width;
     float height;
     Color color;
-    int angle;
 
   static Handle<SceneNode> create(
       Handle<SpriteBatcher> batcher,
       const Rect& rect,
-      const Vector3& position,
+      const Transform& transform,
       float width,
       float height,
-      const Color& color,
-      int angle = 0,
-      Handle<SceneNode> parent = INVALID_HANDLE(SceneNode));
+      const Color& color);
 
   static void destroy(Handle<SceneNode> handle);
 

--- a/src/include/smol/smol_stream_buffer.h
+++ b/src/include/smol/smol_stream_buffer.h
@@ -1,0 +1,30 @@
+#ifndef SMOL_STREAM_BUFFER_H
+#define SMOL_STREAM_BUFFER_H
+
+#include <smol/smol_renderer_types.h>
+
+namespace smol
+{
+  struct StreamBuffer
+  {
+    enum Format
+    {
+      UNINITIALIZED   = 0,
+      POS_COLOR_UV    = 1,
+      POS_COLOR_UV_UV = 2,
+    };
+
+    GLuint vao;
+    GLuint vbo;
+    GLuint ibo;
+    Format format;
+    uint32 indicesPerElement;     // how many indices per element;
+    uint32 capacity;              // maximun number of elements (not bytes!)
+    uint32 used;                  // number of elements stored in the buffer
+    uint32 flushCount;            // used to enlarge the buffer later if we flushed early
+    size_t elementSize;           // size of a sigle element
+    bool bound;
+  };
+}
+#endif //SMOL_STREAM_BUFFER_H
+

--- a/src/include/smol/smol_text_node.h
+++ b/src/include/smol/smol_text_node.h
@@ -1,0 +1,39 @@
+#ifndef SMOL_TEXT_NODE_H
+#define SMOL_TEXT_NODE_H
+
+#include <smol/smol_color.h>
+#include <smol/smol_handle_list.h>
+#include <smol/smol_scene_node_common.h>
+
+namespace smol
+{
+
+  struct SpriteBatcher;
+  struct SceneNode;
+  struct Font;
+  struct Vector3;
+
+  struct TextNode final : public NodeComponent
+  {
+    Arena arena;
+    Handle<Font> font;
+    Handle<SpriteBatcher> batcher;
+    Color color;
+    const char* text;
+
+    void setText(const char* text);
+    const char* getText() const;
+
+    static Handle<SceneNode> create(
+        Handle<SpriteBatcher> batcher,
+        Handle<Font> font,
+        const Vector3& position,
+        const char* text,
+        const Color& color = Color::WHITE,
+        Handle<SceneNode> parent = INVALID_HANDLE(SceneNode));
+
+    static void destroy(Handle<SceneNode> handle);
+  };
+}
+#endif //SMOL_TEXT_NODE_H
+

--- a/src/include/smol/smol_text_node.h
+++ b/src/include/smol/smol_text_node.h
@@ -4,22 +4,38 @@
 #include <smol/smol_color.h>
 #include <smol/smol_handle_list.h>
 #include <smol/smol_scene_node_common.h>
+#include <smol/smol_vector3.h>
+#include <smol/smol_vector2.h>
+#include <smol/smol_rect.h>
+#include <smol/smol_color.h>
 
 namespace smol
 {
+  class Transform;
+
+  struct GlyphDrawData
+  {
+    Vector3 position;
+    Vector2 size;
+    Rectf uv;
+    Color color;
+  };
 
   struct SpriteBatcher;
   struct SceneNode;
   struct Font;
   struct Vector3;
+  struct GlyphDrawData;
 
-  struct TextNode final : public NodeComponent
+  struct SMOL_ENGINE_API TextNode final : public NodeComponent
   {
     Arena arena;
     Handle<Font> font;
     Handle<SpriteBatcher> batcher;
     Color color;
-    const char* text;
+    char* text;
+    GlyphDrawData* drawData;
+    size_t textLen;
 
     void setText(const char* text);
     const char* getText() const;
@@ -27,10 +43,10 @@ namespace smol
     static Handle<SceneNode> create(
         Handle<SpriteBatcher> batcher,
         Handle<Font> font,
-        const Vector3& position,
+        const Transform& transform,
         const char* text,
-        const Color& color = Color::WHITE,
-        Handle<SceneNode> parent = INVALID_HANDLE(SceneNode));
+        const Color& color = Color::WHITE);
+
 
     static void destroy(Handle<SceneNode> handle);
   };

--- a/src/include/smol/smol_texture.h
+++ b/src/include/smol/smol_texture.h
@@ -1,5 +1,6 @@
 #ifndef SMOL_TEXTURE_H
 #define SMOL_TEXTURE_H
+#include <smol/smol_vector2.h>
 
 namespace smol
 {
@@ -37,6 +38,8 @@ namespace smol
       unsigned int glTextureObject;
       // Other Renderer API specific goes here...
     };
+
+    inline Vector2 getDimention() const { return Vector2((float)width, (float)height); }
   };
 
   template class SMOL_ENGINE_API smol::HandleList<smol::Texture>;

--- a/src/include/smol/smol_transform.h
+++ b/src/include/smol/smol_transform.h
@@ -54,7 +54,7 @@ namespace smol
 
     const Vector3& getRotation() const;
 
-    Handle<SceneNode> Transform::getParent() const;
+    Handle<SceneNode> getParent() const;
 
     void setDirty(bool value);
 

--- a/src/smol_arena.cpp
+++ b/src/smol_arena.cpp
@@ -12,7 +12,7 @@ namespace smol
 {
 
   Arena::Arena():
-    used(0), capacity(0), data(nullptr) { }
+    capacity(0), used(0), data(nullptr) { }
 
   Arena::Arena(size_t initialSize) 
   {

--- a/src/smol_camera.cpp
+++ b/src/smol_camera.cpp
@@ -4,20 +4,13 @@
 
 namespace smol
 {
-  Camera::Camera(Type type, float fovOrSize, float zNear, float zFar)
-    :clearOperation(ClearOperation::COLOR | ClearOperation::DEPTH),
-    type(type),
-    clearColor(Color::GRAY),
+  Camera::Camera() :
+    clearOperation(ClearOperation::COLOR | ClearOperation::DEPTH),
+    priority(0),
     layers(Layer::LAYER_0),
     rect(0.0f, 0.0f, 1.0f, 1.0f),
-    priority(0),
-    orthographicSize(0.0f)
-  {
-    if (type == Type::PERSPECTIVE)
-      setPerspective(fovOrSize, zNear, zFar);
-    else
-      setOrthographic(fovOrSize, zNear, zFar);
-  }
+    clearColor(Color::GRAY)
+  {}
 
   Camera& Camera::setPerspective(float fov, float zNear, float zFar)
   {
@@ -28,7 +21,7 @@ namespace smol
     {
       this->type = Camera::PERSPECTIVE;
       this->fov = fov;
-      this->aspect = (float)(viewport.w / viewport.h);
+      this->aspect = ((float)viewport.w /viewport.h);
       this->zNear = zNear;
       this->zFar = zFar;
       this->viewMatrix = Mat4::perspective(fov, aspect, zNear, zFar);

--- a/src/smol_camera_node.cpp
+++ b/src/smol_camera_node.cpp
@@ -1,0 +1,33 @@
+#include <smol/smol_camera_node.h>
+#include <smol/smol_systems_root.h>
+#include <smol/smol_scene.h>
+
+namespace smol
+{
+  CameraNode::CameraNode() : Camera() {}
+
+  Handle<SceneNode> CameraNode::createPerspective(float fov, float zNear, float zFar, Transform& transform)
+  {
+    Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
+    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::CAMERA, transform);
+    handle->camera = CameraNode();
+    handle->camera.setPerspective(fov, zNear, zFar);
+    return handle;
+  }
+
+  Handle<SceneNode> CameraNode::createOrthographic(float size, float zNear, float zFar, Transform& transform)
+  {
+    Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
+    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::CAMERA, transform);
+    handle->camera = CameraNode();
+    handle->camera.setOrthographic(size, zNear, zFar);
+    return handle;
+  }
+
+  void CameraNode::destroy(Handle<SceneNode> handle)
+  {
+    SMOL_ASSERT(handle->typeIs(SceneNode::Type::CAMERA), "Handle passed to CameraNode::destroy() is not of type Camera");
+    SystemsRoot::get()->sceneManager.getLoadedScene().destroyNode(handle);
+  }
+}
+

--- a/src/smol_color.cpp
+++ b/src/smol_color.cpp
@@ -2,6 +2,8 @@
 
 namespace smol
 {
+  Color::Color(): r(0), g(0), b(0), a(0)  { }
+
   Color::Color(int r, int g, int b, int a):
      r(r/255.0f), g(g/255.0f), b(b/255.0f), a(a/255.0f) { }
 

--- a/src/smol_font.cpp
+++ b/src/smol_font.cpp
@@ -1,0 +1,50 @@
+#include <smol/smol_font.h>
+
+namespace smol
+{
+  Font::Font(FontInfo* info): fontInfo(info) 
+  { }
+
+  Handle<Texture> Font::getTexture() const
+  { return fontInfo->texture; }
+
+  const char* Font::getName() const
+  { return fontInfo->name; }
+
+  uint16 Font::getSize() const
+  { return fontInfo->size; }
+
+  uint16 Font::getBase() const
+  { return fontInfo->base; }
+
+  uint16 Font::getLineHeight() const
+  { return fontInfo->lineHeight; }
+
+  uint16 Font::getKerningCount() const
+  { return fontInfo->kerningCount; }
+
+  uint16 Font::getGlyphCount() const
+  { return fontInfo->glyphCount; }
+
+  const Kerning* Font::getKernings(int* count) const
+  { 
+    if (count)
+      *count = fontInfo->kerningCount;
+    return fontInfo->kerning;
+  }
+
+  const Glyph* Font::getGlyphs(int* count) const
+  { 
+    if (count)
+      *count = fontInfo->glyphCount;
+    return fontInfo->glyph;
+  }
+
+#ifndef SMOL_MODULE_GAME
+  const FontInfo* Font::getFontInfo() const
+  {
+    return fontInfo;
+  }
+
+#endif
+}

--- a/src/smol_mesh_node.cpp
+++ b/src/smol_mesh_node.cpp
@@ -1,0 +1,22 @@
+
+#include <smol/smol_mesh_node.h>
+#include <smol/smol_systems_root.h>
+#include <smol/smol_transform.h>
+#include <smol/smol_scene.h>
+
+namespace smol
+{
+    Handle<SceneNode> MeshNode::create(Handle<Renderable> renderable, Transform& transform)
+    {
+      Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
+      Handle<SceneNode> handle = scene.createNode(SceneNode::Type::MESH, transform);
+      handle->mesh.renderable = renderable;
+      return handle;
+    }
+
+  void MeshNode::destroy(Handle<SceneNode> handle)
+  {
+    SMOL_ASSERT(handle->typeIs(SceneNode::Type::MESH), "Handle passed to MeshNode::destroy() is not of type MESH");
+    SystemsRoot::get()->sceneManager.getLoadedScene().destroyNode(handle);
+  }
+}

--- a/src/smol_renderer_gl.cpp
+++ b/src/smol_renderer_gl.cpp
@@ -260,12 +260,12 @@ namespace smol
 
   static inline uint32 getMaterialIndexFromRenderKey(uint64 key)
   {
-    return (uint32) (key >> 16);
+    return ((uint32) key) >> 16;
   }
 
   static inline uint32 getNodeTypeFromRenderKey(uint64 key)
   {
-    return (uint32) (key >> 8);
+    return (uint32) key >> 8;
   }
 
   //NOTE(marcio): We're probably not gonna need it

--- a/src/smol_renderer_gl.cpp
+++ b/src/smol_renderer_gl.cpp
@@ -1180,7 +1180,8 @@ namespace smol
     scene.renderKeysSorted.reset();
 
     // The SCREEN camera. Might be used for GUIs, text and for screen relative sprites
-    Camera screenCamera = Camera(Camera::ORTHOGRAPHIC, screenCameraSize, screenCameraNear, screenCameraFar);
+    Camera screenCamera = Camera();
+    screenCamera.setOrthographic(screenCameraSize, screenCameraNear, screenCameraFar);
 
     // ----------------------------------------------------------------------
     // Update sceneNodes and generate render keys

--- a/src/smol_renderer_gl.cpp
+++ b/src/smol_renderer_gl.cpp
@@ -296,7 +296,7 @@ namespace smol
     glBindVertexArray(0);
   }
 
-  static int drawSpriteNodes(Scene* scene, Renderer* renderer, SpriteBatcher* batcher, uint64* renderKeyList, uint32 cameraLayers)
+  static int drawSpriteNodes(Scene* scene, SpriteBatcher* batcher, uint64* renderKeyList, uint32 cameraLayers)
   {
     const SceneNode* allNodes = scene->nodes.getArray();
 
@@ -351,6 +351,8 @@ namespace smol
     screenCameraSize = config.screenCameraSize;
     screenCameraNear = config.screenCameraNear;
     screenCameraFar = config.screenCameraFar;
+    glEnable(GL_DEBUG_OUTPUT);
+    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
   }
 
   void Renderer::setScene(Scene& scene)
@@ -425,9 +427,6 @@ namespace smol
 
     glGenTextures(1, &outTexture->glTextureObject);
     glBindTexture(GL_TEXTURE_2D, outTexture->glTextureObject);
-
-    GLint internalFormat = GL_RGBA;
-
 
     // if the engine is set to use SRGB ?
     bool useSRGB = SystemsRoot::get()->rendererConfig.enableGammaCorrection;
@@ -686,6 +685,7 @@ namespace smol
     program->valid = false;
   }
 
+
   //
   // Mesh resources
   //
@@ -929,6 +929,228 @@ namespace smol
     glDeleteVertexArrays(1, (const GLuint*) &mesh->vao);
   }
 
+
+  //
+  // StreamBuffer
+  //
+
+  bool Renderer::createStreamBuffer(StreamBuffer* out, uint32 capacity, StreamBuffer::Format format, uint32 indicesPerElement)
+  {
+    out->format = format;
+    out->capacity = capacity;
+    out->used = 0;
+    out->bound = false;
+    out->indicesPerElement = indicesPerElement;
+
+    // VAO
+    glGenVertexArrays(1, &out->vao);
+    glBindVertexArray(out->vao);
+
+    // IBO
+    glGenBuffers(1, &out->ibo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, out->ibo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, out->capacity * indicesPerElement * sizeof(uint32), (void*) nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+    // VBO
+    glGenBuffers(1, &out->vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, out->vbo);
+
+    switch (format)
+    {
+      case StreamBuffer::POS_COLOR_UV:
+        {
+          out->elementSize = 9 * sizeof(float);
+          glVertexAttribPointer(Mesh::POSITION, 3, GL_FLOAT, GL_FALSE, (GLsizei) out->elementSize, (const void*) 0);
+          glVertexAttribPointer(Mesh::COLOR,    4, GL_FLOAT, GL_FALSE, (GLsizei) out->elementSize, (const void*) (3 * sizeof(float)));
+          glVertexAttribPointer(Mesh::UV0,      2, GL_FLOAT, GL_FALSE, (GLsizei) out->elementSize, (const void*) (7 * sizeof(float)));
+
+          glEnableVertexAttribArray(Mesh::POSITION);
+          glEnableVertexAttribArray(Mesh::COLOR);
+          glEnableVertexAttribArray(Mesh::UV0);
+        }
+        break;
+
+      case StreamBuffer::POS_COLOR_UV_UV:
+        {
+          out->elementSize = 11 * sizeof(float);
+          glVertexAttribPointer(Mesh::POSITION, 3, GL_FLOAT, GL_FALSE, (GLsizei)out->elementSize, (const void*) 0);
+          glVertexAttribPointer(Mesh::COLOR,    4, GL_FLOAT, GL_FALSE, (GLsizei)out->elementSize, (const void*) (3 * sizeof(float)));
+          glVertexAttribPointer(Mesh::UV0,      2, GL_FLOAT, GL_FALSE, (GLsizei)out->elementSize, (const void*) (7 * sizeof(float)));
+          glVertexAttribPointer(Mesh::UV1,      2, GL_FLOAT, GL_FALSE, (GLsizei)out->elementSize, (const void*) (9 * sizeof(float)));
+
+          glEnableVertexAttribArray(Mesh::POSITION);
+          glEnableVertexAttribArray(Mesh::COLOR);
+          glEnableVertexAttribArray(Mesh::UV0);
+          glEnableVertexAttribArray(Mesh::UV1);
+        }
+        break;
+
+      default:
+        debugLogError("Unsuported Buffer format %d", (int)format);
+        break;
+    }
+
+    glBufferData(GL_ARRAY_BUFFER, out->elementSize * out->capacity, (void*) nullptr, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    glBindVertexArray(0);
+    return true;
+  }
+
+  bool Renderer::resizeStreamBuffer(StreamBuffer& streamBuffer, uint32 capacity)
+  {
+    if (streamBuffer.format == StreamBuffer::UNINITIALIZED)
+      return false;
+
+    SMOL_ASSERT(streamBuffer.bound == true, "Can't resize and unbound StreamBuffer.");
+    SMOL_ASSERT(streamBuffer.capacity < capacity, "Can't Shrinking a streamBuffer.");
+
+    // resize VBO
+    size_t size = streamBuffer.elementSize * capacity;
+    streamBuffer.capacity = capacity;
+    glBufferData(GL_ARRAY_BUFFER, size, (void*) nullptr, GL_DYNAMIC_DRAW);
+
+    // resize IBO
+    size = capacity * streamBuffer.indicesPerElement * sizeof(uint32);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, (void*) nullptr, GL_DYNAMIC_DRAW);
+    return true;
+  }
+
+  void Renderer::bindStreamBuffer(StreamBuffer& streamBuffer)
+  {
+    if (streamBuffer.format == StreamBuffer::UNINITIALIZED)
+      return;
+
+    if (streamBuffer.bound)
+      return;
+
+    glBindVertexArray(streamBuffer.vao);
+    glBindBuffer(GL_ARRAY_BUFFER, streamBuffer.vbo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, streamBuffer.ibo);
+    streamBuffer.bound = true;
+  }
+
+  void Renderer::unbindStreamBuffer(StreamBuffer& streamBuffer)
+  {
+    if (streamBuffer.format == StreamBuffer::UNINITIALIZED)
+      return;
+
+    if (!streamBuffer.bound)
+      return;
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    streamBuffer.bound = false;
+  }
+
+  bool Renderer::destroyStreamBuffer(StreamBuffer& streamBuffer)
+  {
+    if (streamBuffer.format == StreamBuffer::UNINITIALIZED)
+      return false;
+
+    glDeleteBuffers(1, &streamBuffer.vbo);
+    glDeleteVertexArrays(1, &streamBuffer.vao);
+
+    streamBuffer.capacity = 0;
+    streamBuffer.used     = 0;
+    streamBuffer.vbo      = -1;
+    streamBuffer.vao      = -1;
+    return true;
+  }
+
+  void Renderer::begin(StreamBuffer& streamBuffer)
+  {
+    SMOL_ASSERT(streamBuffer.bound == false, "Cant begin() on a StreamBuffer that is already bound. Did you call begin() twice ?");
+
+    bindStreamBuffer(streamBuffer);
+    streamBuffer.flushCount = 0;
+  }
+
+
+  void Renderer::pushSprite(StreamBuffer& streamBuffer, const Vector3& position, const Vector2& size, const Rectf& uv, const Color& color)
+  {
+    pushSprite(streamBuffer, position, size, uv, color, color, color, color);
+  }
+
+  void Renderer::pushSprite(StreamBuffer& streamBuffer, const Vector3& position, const Vector2& size, const Rectf& uv, const Color& tlColor, const Color& trColor, const Color& blColor, const Color& brColor)
+  {
+    const int indicesPerSprite = 6;
+    const int verticesPerSrprite = 4;
+
+    SMOL_ASSERT(streamBuffer.bound == true, "Cant pushSprite() on a StreamBuffer that is not bound. Did forget to call begin() ?");
+    SMOL_ASSERT(streamBuffer.indicesPerElement == 6,"The current StreamBuffer uses %d indices per element. Pushing a sprite assumes %d indices per element.", streamBuffer.indicesPerElement, indicesPerSprite);
+
+    if (streamBuffer.used + 4 >= streamBuffer.capacity)
+    {
+      flush(streamBuffer);
+    }
+
+    float halfW = size.x/2.0f;
+    float halfH = size.y/2.0f;
+
+    VertexPCU vertex[verticesPerSrprite];
+    uint32 index[indicesPerSprite];
+
+    // Top left 
+    vertex[0].position  = {position.x - halfW, position.y + halfH, position.z};
+    vertex[0].color     = tlColor;
+    vertex[0].uv        = {uv.x, uv.y};
+    // bottom right
+    vertex[1].position  = {position.x + halfW, position.y - halfH, position.z};
+    vertex[1].color     = brColor;
+    vertex[1].uv        = {uv.x + uv.w, uv.y - uv.h};
+    // top right
+    vertex[2].position  = {position.x + halfW, position.y + halfH, position.z};
+    vertex[2].color     = trColor;
+    vertex[2].uv        = {uv.x + uv.w, uv.y};
+    // bottom left
+    vertex[3].position  = {position.x - halfW, position.y - halfH, position.z};
+    vertex[3].color     = blColor;
+    vertex[3].uv        = {uv.x, uv.y - uv.h};
+
+    int numSprites = streamBuffer.used / verticesPerSrprite;
+    int offset = numSprites * 4;
+    index[0] = offset + 0;
+    index[1] = offset + 1;
+    index[2] = offset + 2;
+    index[3] = offset + 0;
+    index[4] = offset + 3;
+    index[5] = offset + 1;
+
+    //TODO(marcio): Map GPU memory and write to it directly to void calling on gl driver so much
+    glBufferSubData(GL_ARRAY_BUFFER, streamBuffer.used * streamBuffer.elementSize, sizeof(vertex), (void*) vertex);
+    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, numSprites * 6 * sizeof(uint32), sizeof(index), (void*) index);
+
+    streamBuffer.used += 4;
+  }
+
+  void Renderer::flush(StreamBuffer& streamBuffer)
+  {
+    int numSprites = streamBuffer.used / 4;
+    int count = numSprites * 6;
+
+    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, nullptr);
+    streamBuffer.flushCount++;
+    streamBuffer.used = 0;
+  }
+
+  void Renderer::end(StreamBuffer& streamBuffer)
+  {
+    SMOL_ASSERT(streamBuffer.bound == true, "Cant end() on a StreamBuffer that is already bound. Did you call end() twice ?");
+    flush(streamBuffer);
+
+    // if flushed more than once before ending, it means we should enlarge the buffer so we don't flush so often
+    uint32 flushCount = streamBuffer.flushCount - 1;
+    if (flushCount > 0)
+    {
+      uint32 newCapacity = streamBuffer.capacity * flushCount * streamBuffer.capacity;
+      resizeStreamBuffer(streamBuffer, newCapacity);
+    }
+    unbindStreamBuffer(streamBuffer);
+  }
+
   //
   // Render
   //
@@ -937,7 +1159,6 @@ namespace smol
   {
     this->viewport.w = width;
     this->viewport.h = height;
-    Scene& scene = *this->scene;
     //OpenGL NDC coords are  LEFT-HANDED.
     //This is a RIGHT-HAND projection matrix.
     glEnable(GL_BLEND);
@@ -950,7 +1171,6 @@ namespace smol
     ResourceManager& resourceManager = SystemsRoot::get()->resourceManager;
     Scene& scene = *this->scene;
     const GLuint defaultShaderProgramId = resourceManager.getDefaultShader().glProgramId;
-    const GLuint defaultTextureId = resourceManager.getDefaultTexture().glTextureObject;
     const Material& defaultMaterial = resourceManager.getDefaultMaterial();
 
     const SceneNode* allNodes = scene.nodes.getArray();
@@ -989,8 +1209,8 @@ namespace smol
           {
             node->transform.update(scene);
             renderable = scene.renderables.lookup(node->mesh.renderable);
-            Material& materialPtr = resourceManager.getMaterial(renderable->material);
-            key = encodeRenderKey(node->getType(), (uint16)(renderable->material.slotIndex), materialPtr.renderQueue, i);
+            Handle<Material> material = renderable->material;
+            key = encodeRenderKey(node->getType(), (uint16)(material.slotIndex), material->renderQueue, i);
           }
           break;
 
@@ -998,12 +1218,11 @@ namespace smol
           {
             if (node->transform.isDirty(scene) || node->isDirty())
             {
-              SpriteBatcher* batcher = scene.batchers.lookup(node->spriteInfo.batcher);
+              SpriteBatcher* batcher = scene.batchers.lookup(node->sprite.batcher);
               batcher->dirty = true;
             }
-            renderable = scene.renderables.lookup(node->spriteInfo.renderable);
-            Material& materialPtr = resourceManager.getMaterial(renderable->material);
-            key = encodeRenderKey(node->getType(), (uint16)(renderable->material.slotIndex), materialPtr.renderQueue, i);
+            Handle<Material> material = node->sprite.batcher->material;
+            key = encodeRenderKey(node->getType(), (uint16)(material.slotIndex), material->renderQueue, i);
           }
           break;
 
@@ -1081,7 +1300,6 @@ namespace smol
       // ----------------------------------------------------------------------
       // Draw render keys
       int currentMaterialIndex = -1;
-      ShaderProgram* shader = nullptr;
       GLuint shaderProgramId = 0; 
       Mat4 identity = Mat4::initIdentity();
 
@@ -1102,7 +1320,6 @@ namespace smol
         if (currentMaterialIndex != materialIndex)
         {
           currentMaterialIndex = materialIndex;
-          const Renderable* renderable = scene.renderables.lookup(node->mesh.renderable);
           Material& material = (resourceManager.getMaterials(nullptr))[materialIndex];
           shaderProgramId = setMaterial(&scene, &material, cameraNode);
         }
@@ -1120,10 +1337,9 @@ namespace smol
         }
         else if (node->typeIs(SceneNode::SPRITE))
         {
-          SpriteBatcher* batcher = scene.batchers.lookup(node->spriteInfo.batcher);
+          SpriteBatcher* batcher = scene.batchers.lookup(node->sprite.batcher);
           if(batcher->dirty)
           {
-
             if (batcher->mode == SpriteBatcher::CAMERA)
             {
               // Relative to current camera
@@ -1147,18 +1363,17 @@ namespace smol
               glBufferSubData(GL_UNIFORM_BUFFER, SMOL_UBO_MAT4_MODEL, sizeof(Mat4),
                   (const float*) identity.e);
             }
-            drawSpriteNodes(&scene, this, batcher, allRenderKeys + i, cameraLayers);
+
             // keep it dirty while there are cameras to render
             if (cameraIndex == numCameras - 1)
             {
               batcher->dirty = false;
             }
+            //draw
+             drawSpriteNodes(&scene, batcher, allRenderKeys + i, cameraLayers);
           }
-
-          //draw
-          Renderable* renderable = scene.renderables.lookup(node->spriteInfo.renderable);
-          drawRenderable(&scene, renderable, shaderProgramId);
-          i+=batcher->spriteCount - 1;
+          // skip all nodes handled by the current batcher
+          i+=batcher->nodeCount - 1;
         }
         else
         {
@@ -1171,8 +1386,8 @@ namespace smol
     resized = false;
 
     // unbind the last shader and textures (material)
-    glUseProgram(defaultShaderProgramId);
     glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    glUseProgram(defaultShaderProgramId);
     for (int i = 0; i < defaultMaterial.diffuseTextureCount; i++)
     {
       glActiveTexture(GL_TEXTURE0 + i);

--- a/src/smol_renderer_gl.cpp
+++ b/src/smol_renderer_gl.cpp
@@ -249,7 +249,7 @@ namespace smol
     // Render key format
     // 64--------------------32---------------16-----------8---------------0
     // sceneNode index       | material index  | node type | render queue
-    uint64 key = ((uint64) nodeIndex) << 32 | ((uint16) materialIndex) << 24 |  nodeType << 8 | (uint8) queue;
+    uint64 key = ((uint64) nodeIndex) << 32 | ((uint16) materialIndex) << 16 |  nodeType << 8 | (uint8) queue;
     return key;
   }
 
@@ -1103,7 +1103,7 @@ namespace smol
         {
           currentMaterialIndex = materialIndex;
           const Renderable* renderable = scene.renderables.lookup(node->mesh.renderable);
-          Material& material = resourceManager.getMaterial(renderable->material);
+          Material& material = (resourceManager.getMaterials(nullptr))[materialIndex];
           shaderProgramId = setMaterial(&scene, &material, cameraNode);
         }
 

--- a/src/smol_resource_manager.cpp
+++ b/src/smol_resource_manager.cpp
@@ -746,7 +746,7 @@ namespace smol
     ResourceManager::unloadImage(img);
 
     // Make the default ShaderProgram
-    ShaderProgram& program = Renderer::getDefaultShaderProgram();
+    const ShaderProgram& program = Renderer::getDefaultShaderProgram();
     Handle<ShaderProgram> defaultShaderHandle = shaders.add(program);
 
     // Make the default Material

--- a/src/smol_resource_manager.cpp
+++ b/src/smol_resource_manager.cpp
@@ -277,7 +277,7 @@ namespace smol
 
     size_t nameLen = strlen(path);
     SMOL_ASSERT(nameLen < Material::MAX_NAME_LEN, "Material name exceeded %d charecter", Material::MAX_NAME_LEN);
-    strncpy(material->name, path, nameLen);
+    strncpy(material->name, path, nameLen + 1);
 
     //set values for material parameters
     for(int i = 0; i < material->parameterCount; i++)
@@ -364,7 +364,7 @@ namespace smol
     const char* materialName = "custom_material";
     size_t nameLen = strlen(materialName);
     SMOL_ASSERT(nameLen < Material::MAX_NAME_LEN, "Material name exceeded %d charecter", Material::MAX_NAME_LEN);
-    strncpy(material.name, materialName, nameLen);
+    strncpy(material.name, materialName, nameLen + 1);
 
     if (diffuseTextureCount)
     {
@@ -665,8 +665,7 @@ namespace smol
     info->name          = (memory + sizeof(FontInfo) + sizeof(Kerning) * kerningCount + sizeof(Glyph) * glyphCount);
 
     // copy the font name after the Font structure and null terminate it
-    strncpy((char*)info->name, fontName, fontNameLen);
-    *((char*)info->name + fontNameLen) = 0;
+    strncpy((char*)info->name, fontName, fontNameLen + 1);
 
     // parse kerning pairs
     ConfigEntry *last = nullptr;

--- a/src/smol_scene.cpp
+++ b/src/smol_scene.cpp
@@ -160,17 +160,6 @@ namespace smol
     mainCamera = handle;
   }
 
-  Handle<SceneNode> Scene::clone(Handle<SceneNode> handle)
-  {
-    Handle<SceneNode> newHandle = nodes.reserve();
-    SceneNode* newNode = nodes.lookup(newHandle);
-    SceneNode* original = nodes.lookup(handle);
-    memcpy(newNode, original, sizeof(SceneNode));
-
-    //TODO(marcio): this won't work for sprites because it does not update spriteCount on the spriteBatcher. Fix it!
-    return newHandle;
-  }
-
   SceneNode& Scene::getNode(Handle<SceneNode> handle) const
   {
     SceneNode* node = nodes.lookup(handle);

--- a/src/smol_scene.cpp
+++ b/src/smol_scene.cpp
@@ -24,7 +24,6 @@ namespace smol
     batchers(8 * sizeof(SpriteBatcher)),
     renderKeys(1024 * sizeof(uint64)),
     renderKeysSorted(1024 * sizeof(uint64)),
-    mainCamera(INVALID_HANDLE(SceneNode)),
     nullSceneNode(this, SceneNode::Type::INVALID)
   {
     viewMatrix = Mat4::initIdentity();
@@ -105,16 +104,6 @@ namespace smol
     nodes.remove(handle);
   }
 #endif
-
-
-  void Scene::setMainCamera(Handle<SceneNode> handle)
-  {
-    SceneNode* node = nodes.lookup(handle);
-    if (!node || !node->typeIs(SceneNode::Type::CAMERA))
-      return;
-
-    mainCamera = handle;
-  }
 
   SceneNode& Scene::getNode(Handle<SceneNode> handle) const
   {

--- a/src/smol_scene.cpp
+++ b/src/smol_scene.cpp
@@ -119,6 +119,7 @@ namespace smol
     node->spriteInfo.sprite.height = height;
     node->spriteInfo.sprite.angle = angle;
     node->spriteInfo.sprite.color = color;
+    node->spriteInfo.spriteCount = 1;
 
 
     SpriteBatcher* batcherPtr = batchers.lookup(batcher);
@@ -211,6 +212,9 @@ namespace smol
     if (node)
     {
       nodes.remove(handle);
+
+      if (node->typeIs(SceneNode::SPRITE))
+        node->spriteInfo.~SpriteNodeInfo();
     }
   }
 

--- a/src/smol_scene.cpp
+++ b/src/smol_scene.cpp
@@ -106,21 +106,6 @@ namespace smol
   }
 #endif
 
-  Handle<SceneNode> Scene::createPerspectiveCameraNode(float fov, float zNear, float zFar, const Transform& transform)
-  {
-    Handle<SceneNode> handle = nodes.add(SceneNode(this, SceneNode::CAMERA, transform));
-    SceneNode* node = nodes.lookup(handle);
-    node->camera = Camera(Camera::PERSPECTIVE, fov, zNear, zFar);
-    return handle;
-  }
-
-  Handle<SceneNode> Scene::createOrthographicCameraNode(float size, float zNear, float zFar, const Transform& transform)
-  {
-    Handle<SceneNode> handle = nodes.add(SceneNode(this, SceneNode::CAMERA, transform));
-    SceneNode* node = nodes.lookup(handle);
-    node->camera = Camera(Camera::ORTHOGRAPHIC, size, zNear, zFar);
-    return handle;
-  }
 
   void Scene::setMainCamera(Handle<SceneNode> handle)
   {

--- a/src/smol_scene.cpp
+++ b/src/smol_scene.cpp
@@ -88,10 +88,8 @@ namespace smol
   //
 
 #ifndef SMOL_MODULE_GAME
-  Handle<SceneNode> Scene::createNode(SceneNode::Type type, Transform& transform)
+  Handle<SceneNode> Scene::createNode(SceneNode::Type type, const Transform& transform)
   {
-    if (transform.getParent() == INVALID_HANDLE(SceneNode))
-      transform.setParent(Scene::ROOT);
     Handle<SceneNode> handle = nodes.add(SceneNode(this, type, transform));
     handle->setDirty(true);
     return handle;

--- a/src/smol_scene.cpp
+++ b/src/smol_scene.cpp
@@ -113,19 +113,20 @@ namespace smol
     Handle<SceneNode> handle = nodes.add(SceneNode(this, SceneNode::SPRITE, t));
     SceneNode* node = nodes.lookup(handle);
 
-    node->sprite.rect = rect;
-    node->sprite.batcher = batcher;
-    node->sprite.width = width;
-    node->sprite.height = height;
-    node->sprite.angle = angle;
-    node->sprite.color = color;
+    node->spriteInfo.sprite.rect = rect;
+    node->spriteInfo.batcher = batcher;
+    node->spriteInfo.sprite.width = width;
+    node->spriteInfo.sprite.height = height;
+    node->spriteInfo.sprite.angle = angle;
+    node->spriteInfo.sprite.color = color;
 
 
     SpriteBatcher* batcherPtr = batchers.lookup(batcher);
     if (batcherPtr)
     {
       // copy the renderable handle to the node level
-      node->sprite.renderable = batcherPtr->renderable;
+      node->spriteInfo.renderable = batcherPtr->renderable;
+      batcherPtr->nodeCount++;
       batcherPtr->spriteCount++;
       batcherPtr->dirty = true;
     }

--- a/src/smol_scene_node.cpp
+++ b/src/smol_scene_node.cpp
@@ -1,35 +1,10 @@
 #include <smol/smol_transform.h>
 #include <smol/smol_scene.h> // also includes smol_scene_nodes.h
+#include <smol/smol_renderer_types.h>
 
 namespace smol
 {
   struct Scene;
-
-  //---------------------------------------------------------------------------
-  // MeshNodeInfo
-  //---------------------------------------------------------------------------
-  MeshNodeInfo::~MeshNodeInfo()
-  {
-  }
-
-
-  //---------------------------------------------------------------------------
-  // SpriteNodeInfo
-  //---------------------------------------------------------------------------
-  SpriteNodeInfo::SpriteNodeInfo():arena(0), spriteCount(1)
-  {
-  }
-
-  SpriteNodeInfo::~SpriteNodeInfo()
-  {
-    batcher->spriteCount -= spriteCount; 
-    batcher->nodeCount--;
-  }
-
-  SceneNode::SceneNode(Scene* scene, SceneNode::Type type, const Transform& transform)
-    :transform(transform), scene(*scene), active(true), dirty(true), type(type), layer(Layer::LAYER_0)
-  { 
-  }
 
   //---------------------------------------------------------------------------
   // SceneNode

--- a/src/smol_scene_nodes.cpp
+++ b/src/smol_scene_nodes.cpp
@@ -12,13 +12,14 @@ namespace smol
   {
   }
 
-  SpriteNodeInfo::SpriteNodeInfo():arena(0), spriteCount(1)
-  {
-  }
 
   //---------------------------------------------------------------------------
   // SpriteNodeInfo
   //---------------------------------------------------------------------------
+  SpriteNodeInfo::SpriteNodeInfo():arena(0), spriteCount(1)
+  {
+  }
+
   SpriteNodeInfo::~SpriteNodeInfo()
   {
     batcher->spriteCount -= spriteCount; 
@@ -34,6 +35,11 @@ namespace smol
   // SceneNode
   //---------------------------------------------------------------------------
   SceneNode::~SceneNode() { }
+
+  SceneNode::SceneNode(Scene* scene, SceneNode::Type type, const Transform& transform)
+    :transform(transform), scene(*scene), active(true), dirty(true), type(type), layer(Layer::LAYER_0)
+  { 
+  }
 
   void SceneNode::setActive(bool status)
   {

--- a/src/smol_scene_nodes.cpp
+++ b/src/smol_scene_nodes.cpp
@@ -5,13 +5,36 @@ namespace smol
 {
   struct Scene;
 
+  //---------------------------------------------------------------------------
+  // MeshNodeInfo
+  //---------------------------------------------------------------------------
+  MeshNodeInfo::~MeshNodeInfo()
+  {
+  }
+
+  SpriteNodeInfo::SpriteNodeInfo():arena(0), spriteCount(1)
+  {
+  }
+
+  //---------------------------------------------------------------------------
+  // SpriteNodeInfo
+  //---------------------------------------------------------------------------
+  SpriteNodeInfo::~SpriteNodeInfo()
+  {
+    batcher->spriteCount -= spriteCount; 
+    batcher->nodeCount--;
+  }
+
   SceneNode::SceneNode(Scene* scene, SceneNode::Type type, const Transform& transform)
     :transform(transform), scene(*scene), active(true), dirty(true), type(type), layer(Layer::LAYER_0)
   { 
   }
 
+  //---------------------------------------------------------------------------
+  // SceneNode
+  //---------------------------------------------------------------------------
   SceneNode::~SceneNode() { }
-  
+
   void SceneNode::setActive(bool status)
   {
     if (!isValid())
@@ -66,6 +89,6 @@ namespace smol
     }
     transform.setParent(parent);
   }
-  
+
   void SceneNode::setLayer(smol::Layer l) { layer = l; }
 }

--- a/src/smol_scene_nodes.cpp
+++ b/src/smol_scene_nodes.cpp
@@ -9,6 +9,8 @@ namespace smol
     :transform(transform), scene(*scene), active(true), dirty(true), type(type), layer(Layer::LAYER_0)
   { 
   }
+
+  SceneNode::~SceneNode() { }
   
   void SceneNode::setActive(bool status)
   {

--- a/src/smol_sprite_batcher.cpp
+++ b/src/smol_sprite_batcher.cpp
@@ -12,7 +12,8 @@ namespace smol
   SpriteBatcher::SpriteBatcher(Handle<Material> material, Mode mode, int capacity):
     mode(mode),
     material(material),
-    nodeCount(0),
+    spriteNodeCount(0),
+    textNodeCount(0),
     dirty(false)
   {
     Renderer::createStreamBuffer(&buffer, 64);
@@ -40,8 +41,10 @@ namespace smol
 
   void SpriteBatcher::pushSpriteNode(SceneNode* sceneNode)
   {
-    //TODO(marcio): Make sure we don't push more sprites than expected;
-    //TODO(marcio): Make sure we received real SpriteNodes
+    SMOL_ASSERT(sceneNode->typeIs(SceneNode::SPRITE),
+        "A node of type '%d' was passed to SpriteBatcher::pushSpriteNode(). It can only accept SPRITE (%d) nodes",
+        sceneNode->getType(), SceneNode::SPRITE);
+    
     SpriteNode& node = sceneNode->sprite;
     float textureWidth = textureDimention.x;
     float textureHeight = textureDimention.y;
@@ -57,4 +60,19 @@ namespace smol
     const Vector3& pos = sceneNode->transform.getPosition();
     Renderer::pushSprite(buffer, pos, {node.width, node.height}, uvRect, node.color);
   }
+
+  void SpriteBatcher::pushTextNode(SceneNode* sceneNode)
+  {
+    SMOL_ASSERT(sceneNode->typeIs(SceneNode::TEXT),
+        "A node of type '%d' was passed to SpriteBatcher::pushSpriteNode(). It can only accept SPRITE (%d) nodes",
+        sceneNode->getType(), SceneNode::TEXT);
+    TextNode& node = sceneNode->text;
+    
+    for (int i = 0; i < node.textLen; i++)
+    {
+      GlyphDrawData& data = node.drawData[i];
+      Renderer::pushSprite(buffer, data.position, data.size, data.uv, data.color);
+    }
+  }
+
 }

--- a/src/smol_sprite_batcher.cpp
+++ b/src/smol_sprite_batcher.cpp
@@ -9,80 +9,40 @@
 
 namespace smol
 {
-  const size_t SpriteBatcher::positionsSize   = 4 * sizeof(Vector3);
-  const size_t SpriteBatcher::colorsSize      = 4 * sizeof(Color);
-  const size_t SpriteBatcher::uvsSize         = 4 * sizeof(Vector2);
-  const size_t SpriteBatcher::indicesSize     = 6 * sizeof(unsigned int);
-  const size_t SpriteBatcher::totalSpriteSize = positionsSize + colorsSize + uvsSize + indicesSize;
-
   SpriteBatcher::SpriteBatcher(Handle<Material> material, Mode mode, int capacity):
     mode(mode),
-    arena(capacity * totalSpriteSize + 1),
+    material(material),
     nodeCount(0),
-    spriteCount(0),
-    batchedSprites(0),
-    spriteCapacity(capacity),
     dirty(false)
   {
-    ResourceManager& resourceManager = SystemsRoot::get()->resourceManager;
-    Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
-    // It doesn't matter the contents of memory.
-    // Nothing is read from this pointer.
-    // It's just necessary to create a valid MeshData in order to reserve GPU memory
-    //TODO(marcio): Do we really need to reserve memory to create a dummy MeshData ? Can't we just updateMesh() on the first real use ?
-    char* memory = arena.pushSize(capacity * SpriteBatcher::totalSpriteSize);
-    MeshData meshData((Vector3*)memory, capacity, 
-        (unsigned int*)memory, capacity * 6,
-        (Color*) memory, nullptr,
-        (Vector2*) memory, nullptr);
-
-    renderable = scene.createRenderable(material, resourceManager.createMesh(true, meshData));
-  }
-
-  size_t SpriteBatcher::getTotalSizeRequired() const
-  {
-    return spriteCount * SpriteBatcher::totalSpriteSize;
+    Renderer::createStreamBuffer(&buffer, 64);
   }
 
   void SpriteBatcher::begin()
   {
-    batchedSprites = 0;
-    arena.reset();
-
-    // Reserve space for all sprites
-    const size_t totalSize  = spriteCount * SpriteBatcher::totalSpriteSize;
-    memory                  = arena.pushSize(totalSize);
-    positions               = (Vector3*) memory;
-    colors                  = (Color*)(positions + spriteCount * 4);
-    uvs                     = (Vector2*)(colors + spriteCount * 4);
-    indices                 = (uint32*)(uvs + spriteCount * 4);
 
     // cache the renderable texture dimention so adjust sprite's UVs
-    if (renderable->material->diffuseTextureCount > 0 )
+    if (material->diffuseTextureCount > 0 )
     {
-      textureDimention = renderable->material->textureDiffuse[0]->getDimention();
+      textureDimention = material->textureDiffuse[0]->getDimention();
     }
     else
     {
       textureDimention = SystemsRoot::get()->resourceManager.getDefaultTexture().getDimention();
     }
+    Renderer::begin(buffer);
   }
 
   void SpriteBatcher::end()
   {
-    MeshData meshData(positions, 4 * batchedSprites, indices, 6 * batchedSprites, colors, nullptr, uvs);
-    ResourceManager& resourceManager = SystemsRoot::get()->resourceManager;
-    Mesh* mesh = resourceManager.getMesh(renderable->mesh);
-    Renderer::updateMesh(mesh, &meshData);
+    Renderer::end(buffer);
   }
 
   void SpriteBatcher::pushSpriteNode(SceneNode* sceneNode)
   {
     //TODO(marcio): Make sure we don't push more sprites than expected;
-    //TODO(marcio): Make sure we don't push more nodes than expected;
     //TODO(marcio): Make sure we received real SpriteNodes
-    
-    Sprite& node = sceneNode->spriteInfo.sprite;
+    SpriteNode& node = sceneNode->sprite;
     float textureWidth = textureDimention.x;
     float textureHeight = textureDimention.y;
 
@@ -94,38 +54,7 @@ namespace smol
     uvRect.w = node.rect.w / (float) textureWidth;
     uvRect.h = node.rect.h / (float) textureHeight;
 
-    Vector3* pVertex  = (4 * batchedSprites)  + positions;
-    Vector2* pUVs     = (4 * batchedSprites)  + uvs;
-    uint32* pIndices  = (6 * batchedSprites)  + indices;
-    Color* pColors    = (4 * batchedSprites)  + colors;
-    int offset        = (4 * batchedSprites);
-
     const Vector3& pos = sceneNode->transform.getPosition();
-    float halfW = node.width/2.0f;
-    float halfH = node.height/2.0f;
-
-    pVertex[0] = {pos.x - halfW, pos.y + halfH, pos.z};             // top left
-    pVertex[1] = {pos.x + halfW, pos.y - halfH, pos.z};             // bottom right
-    pVertex[2] = {pos.x + halfW, pos.y + halfH, pos.z};             // top right
-    pVertex[3] = {pos.x - halfW, pos.y - halfH, pos.z};             // bottom left
-
-    pColors[0] = node.color;                                        // top left
-    pColors[1] = node.color;                                        // bottom right
-    pColors[2] = node.color;                                        // top right
-    pColors[3] = node.color;                                        // bottom left
-
-    pUVs[0] = {uvRect.x, uvRect.y};                                 // top left 
-    pUVs[1] = {uvRect.x + uvRect.w, uvRect.y - uvRect.h};           // bottom right
-    pUVs[2] = {uvRect.x + uvRect.w, uvRect.y};                      // top right
-    pUVs[3] = {uvRect.x, uvRect.y - uvRect.h};                      // bottom left
-
-    pIndices[0] = offset + 0;
-    pIndices[1] = offset + 1;
-    pIndices[2] = offset + 2;
-    pIndices[3] = offset + 0;
-    pIndices[4] = offset + 3;
-    pIndices[5] = offset + 1;
-
-    batchedSprites++;
+    Renderer::pushSprite(buffer, pos, {node.width, node.height}, uvRect, node.color);
   }
 }

--- a/src/smol_sprite_batcher.cpp
+++ b/src/smol_sprite_batcher.cpp
@@ -18,7 +18,9 @@ namespace smol
   SpriteBatcher::SpriteBatcher(Handle<Material> material, Mode mode, int capacity):
     mode(mode),
     arena(capacity * totalSpriteSize + 1),
+    nodeCount(0),
     spriteCount(0),
+    batchedSprites(0),
     spriteCapacity(capacity),
     dirty(false)
   {
@@ -27,6 +29,7 @@ namespace smol
     // It doesn't matter the contents of memory.
     // Nothing is read from this pointer.
     // It's just necessary to create a valid MeshData in order to reserve GPU memory
+    //TODO(marcio): Do we really need to reserve memory to create a dummy MeshData ? Can't we just updateMesh() on the first real use ?
     char* memory = arena.pushSize(capacity * SpriteBatcher::totalSpriteSize);
     MeshData meshData((Vector3*)memory, capacity, 
         (unsigned int*)memory, capacity * 6,
@@ -34,5 +37,95 @@ namespace smol
         (Vector2*) memory, nullptr);
 
     renderable = scene.createRenderable(material, resourceManager.createMesh(true, meshData));
+  }
+
+  size_t SpriteBatcher::getTotalSizeRequired() const
+  {
+    return spriteCount * SpriteBatcher::totalSpriteSize;
+  }
+
+  void SpriteBatcher::begin()
+  {
+    batchedSprites = 0;
+    arena.reset();
+
+    // Reserve space for all sprites
+    const size_t totalSize  = spriteCount * SpriteBatcher::totalSpriteSize;
+    memory                  = arena.pushSize(totalSize);
+    positions               = (Vector3*) memory;
+    colors                  = (Color*)(positions + spriteCount * 4);
+    uvs                     = (Vector2*)(colors + spriteCount * 4);
+    indices                 = (uint32*)(uvs + spriteCount * 4);
+
+    // cache the renderable texture dimention so adjust sprite's UVs
+    if (renderable->material->diffuseTextureCount > 0 )
+    {
+      textureDimention = renderable->material->textureDiffuse[0]->getDimention();
+    }
+    else
+    {
+      textureDimention = SystemsRoot::get()->resourceManager.getDefaultTexture().getDimention();
+    }
+  }
+
+  void SpriteBatcher::end()
+  {
+    MeshData meshData(positions, 4 * batchedSprites, indices, 6 * batchedSprites, colors, nullptr, uvs);
+    ResourceManager& resourceManager = SystemsRoot::get()->resourceManager;
+    Mesh* mesh = resourceManager.getMesh(renderable->mesh);
+    Renderer::updateMesh(mesh, &meshData);
+  }
+
+  void SpriteBatcher::pushSpriteNode(SceneNode* sceneNode)
+  {
+    //TODO(marcio): Make sure we don't push more sprites than expected;
+    //TODO(marcio): Make sure we don't push more nodes than expected;
+    //TODO(marcio): Make sure we received real SpriteNodes
+    
+    Sprite& node = sceneNode->spriteInfo.sprite;
+    float textureWidth = textureDimention.x;
+    float textureHeight = textureDimention.y;
+
+    // convert UVs from pixels to 0~1 range
+    // pixel coords origin is at top left corner
+    Rectf uvRect;
+    uvRect.x = node.rect.x / (float) textureWidth;
+    uvRect.y = 1 - (node.rect.y /(float) textureHeight); 
+    uvRect.w = node.rect.w / (float) textureWidth;
+    uvRect.h = node.rect.h / (float) textureHeight;
+
+    Vector3* pVertex  = (4 * batchedSprites)  + positions;
+    Vector2* pUVs     = (4 * batchedSprites)  + uvs;
+    uint32* pIndices  = (6 * batchedSprites)  + indices;
+    Color* pColors    = (4 * batchedSprites)  + colors;
+    int offset        = (4 * batchedSprites);
+
+    const Vector3& pos = sceneNode->transform.getPosition();
+    float halfW = node.width/2.0f;
+    float halfH = node.height/2.0f;
+
+    pVertex[0] = {pos.x - halfW, pos.y + halfH, pos.z};             // top left
+    pVertex[1] = {pos.x + halfW, pos.y - halfH, pos.z};             // bottom right
+    pVertex[2] = {pos.x + halfW, pos.y + halfH, pos.z};             // top right
+    pVertex[3] = {pos.x - halfW, pos.y - halfH, pos.z};             // bottom left
+
+    pColors[0] = node.color;                                        // top left
+    pColors[1] = node.color;                                        // bottom right
+    pColors[2] = node.color;                                        // top right
+    pColors[3] = node.color;                                        // bottom left
+
+    pUVs[0] = {uvRect.x, uvRect.y};                                 // top left 
+    pUVs[1] = {uvRect.x + uvRect.w, uvRect.y - uvRect.h};           // bottom right
+    pUVs[2] = {uvRect.x + uvRect.w, uvRect.y};                      // top right
+    pUVs[3] = {uvRect.x, uvRect.y - uvRect.h};                      // bottom left
+
+    pIndices[0] = offset + 0;
+    pIndices[1] = offset + 1;
+    pIndices[2] = offset + 2;
+    pIndices[3] = offset + 0;
+    pIndices[4] = offset + 3;
+    pIndices[5] = offset + 1;
+
+    batchedSprites++;
   }
 }

--- a/src/smol_sprite_node.cpp
+++ b/src/smol_sprite_node.cpp
@@ -1,0 +1,47 @@
+//TODO(marcio): Is it a good idea to make batcher creation/destruction implicit for meshNodes ? 
+
+#include <smol/smol_sprite_node.h>
+#include <smol/smol_transform.h>
+#include <smol/smol_scene.h>
+
+namespace smol
+{
+
+  Handle<SceneNode> SpriteNode::create(
+      Handle<SpriteBatcher> batcher,
+      const Rect& rect,
+      const Vector3& position,
+      float width,
+      float height,
+      const Color& color,
+      int angle,
+      Handle<SceneNode> parent)
+  {
+    Transform t(
+        position,
+        Vector3(0.0f, 0.0f, 0.0f),
+        Vector3(1.0f, 1.0f, 1.0f),
+        parent);
+
+    Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
+    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::SPRITE, t);
+
+    handle->sprite.rect = rect;
+    handle->sprite.batcher = batcher;
+    handle->sprite.width = width;
+    handle->sprite.height = height;
+    handle->sprite.angle = angle;
+    handle->sprite.color = color;
+
+    batcher->nodeCount++;
+    batcher->dirty = true;
+    return handle;
+  }
+
+  void SpriteNode::destroy(Handle<SceneNode> handle)
+  {
+    SMOL_ASSERT(handle->typeIs(SceneNode::Type::SPRITE), "Handle passed to SpriteNode::destroy() is not of type SPRITE");
+    SystemsRoot::get()->sceneManager.getLoadedScene().destroyNode(handle);
+    handle->sprite.batcher->nodeCount--;
+  }
+}

--- a/src/smol_sprite_node.cpp
+++ b/src/smol_sprite_node.cpp
@@ -10,30 +10,20 @@ namespace smol
   Handle<SceneNode> SpriteNode::create(
       Handle<SpriteBatcher> batcher,
       const Rect& rect,
-      const Vector3& position,
+      const Transform& transform,
       float width,
       float height,
-      const Color& color,
-      int angle,
-      Handle<SceneNode> parent)
+      const Color& color)
   {
-    Transform t(
-        position,
-        Vector3(0.0f, 0.0f, 0.0f),
-        Vector3(1.0f, 1.0f, 1.0f),
-        parent);
-
     Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
-    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::SPRITE, t);
+    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::SPRITE, transform);
 
     handle->sprite.rect = rect;
     handle->sprite.batcher = batcher;
     handle->sprite.width = width;
     handle->sprite.height = height;
-    handle->sprite.angle = angle;
     handle->sprite.color = color;
-
-    batcher->nodeCount++;
+    batcher->spriteNodeCount++;
     batcher->dirty = true;
     return handle;
   }
@@ -42,6 +32,6 @@ namespace smol
   {
     SMOL_ASSERT(handle->typeIs(SceneNode::Type::SPRITE), "Handle passed to SpriteNode::destroy() is not of type SPRITE");
     SystemsRoot::get()->sceneManager.getLoadedScene().destroyNode(handle);
-    handle->sprite.batcher->nodeCount--;
+    handle->sprite.batcher->spriteNodeCount--;
   }
 }

--- a/src/smol_text_node.cpp
+++ b/src/smol_text_node.cpp
@@ -4,44 +4,139 @@
 #include <smol/smol_transform.h>
 #include <smol/smol_systems_root.h>
 #include <smol/smol_scene.h>
+#include <string.h>
 
 namespace smol
 {
+  // Helper functions for generating draw data for text based on the current font
+  static float computeGlyph(const smol::Glyph& glyph, float x, float y, float z,
+      const smol::Kerning* kernings, uint16 kerningCount,
+      Handle<SpriteBatcher> batcher,
+      smol::Color color,
+      Vector2& textureSize,
+      GlyphDrawData* drawData)
+  {
+    const float scale = 0.01f;
+    const float width   = glyph.rect.w * scale;
+    const float height  = glyph.rect.h * scale;
+    const float yOffset = glyph.yOffset * scale;
+
+    // offset by half height because our pivots are at center
+    const float xOffset = glyph.xOffset * scale + width/2;
+    const float xAdvance = glyph.xAdvance * scale;
+    // offset by half height because our pivots are at center
+    y -= height/2.0f + yOffset;
+
+    // apply kerning
+    float kerning = 0.0f;
+    for (int i = 0; i < kerningCount; i++)
+    {
+      const smol::Kerning& k = kernings[i];
+      if(k.second == glyph.id)
+      {
+        kerning = k.amount * scale;
+        break;
+      }
+    }
+
+    drawData->position = smol::Vector3(x + xOffset + kerning, y, z);
+    drawData->size = Vector2(width, height);
+    drawData->color = color;
+
+    // convert UVs from pixels to 0 ~ 1 range
+    drawData->uv.x = glyph.rect.x / textureSize.x;
+    drawData->uv.y = 1 - (glyph.rect.y / textureSize.y);
+    drawData->uv.w = glyph.rect.w / textureSize.x;
+    drawData->uv.h = glyph.rect.h / textureSize.y;
+
+    return x + xAdvance + kerning;
+  }
+
+  static void computeString(const char* str, smol::Handle<smol::Font> font, Vector3& position,
+      Handle<SpriteBatcher> batcher, smol::Color color, GlyphDrawData* drawData)
+  {
+    float x = position.x;
+    float y = position.y;
+    float z = position.z;
+    float advance = x;
+    const smol::Kerning* kerning = nullptr;
+    uint16 kerningCount = 0;
+
+    int glyphCount;
+    const smol::Glyph* glyphList = font->getGlyphs(&glyphCount);
+
+    const smol::Kerning* kerningList = font->getKernings();
+    const uint16 lineHeight = font->getLineHeight();
+    Vector2 textureSize = batcher->material->textureDiffuse[0]->getDimention();
+
+    while (*str != 0)
+    {
+      for (int i = 0; i < glyphCount; i++)
+      {
+        uint16 id = (uint16) *str;
+
+        const smol::Glyph& glyph = glyphList[i];
+        if (glyph.id == id)
+        {
+          if ((char)id == '\n')
+          {
+            y -= lineHeight / 100.0f;
+            advance = x;
+          }
+          advance = computeGlyph(glyph, advance, y, z, kerning, kerningCount, batcher, color, textureSize, drawData++);
+          // kerning information for the next character
+          kerning = &kerningList[glyph.kerningStart];
+          kerningCount = glyph.kerningCount;
+          break;
+        }
+      }
+      str++;
+    }
+  }
+
   Handle<SceneNode> TextNode::create(
       Handle<SpriteBatcher> batcher,
       Handle<Font> font,
-      const Vector3& position,
+      const Transform& transform,
       const char* text,
-      const Color& color,
-      Handle<SceneNode> parent)
+      const Color& color)
   {
-    Transform t(
-        position,
-        Vector3(0.0f, 0.0f, 0.0f),
-        Vector3(1.0f, 1.0f, 1.0f),
-        parent);
-
     Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
-    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::TEXT, t);
-    handle->text.batcher = batcher;
+    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::TEXT, transform);
+    TextNode& textNode = scene.getNode(handle).text;
+    textNode.batcher = batcher;
+    textNode.font = font;
+    textNode.node = handle;
+    textNode.color = color;
+    textNode.arena.initialize(0); // let setText() decide how much to allocate
+    textNode.batcher->textNodeCount++;
+    textNode.batcher->dirty = true;
     handle->text.setText(text);
-    batcher->nodeCount++;
-    batcher->dirty = true;
-    handle->text.node = handle;
     return handle;
   }
 
   void TextNode::setText(const char* text)
   {
-    size_t textLen = strlen(text);
-    size_t memSize = textLen + 1 + textLen * sizeof(VertexPCU);
+    textLen = strlen(text);
+    size_t memSize = textLen + 1 + textLen * sizeof(GlyphDrawData);
     if (arena.getCapacity() == 0)
     {
       arena.initialize(memSize);
     }
-    //arena.reset();
-    //char* memory =  (char*) arena.pushSize(textLen);
-    //...
+    else
+    {
+      arena.reset();
+    }
+
+    char* memory =  (char*) arena.pushSize(memSize);
+    this->drawData = (GlyphDrawData*) memory;
+    this->text = memory + (sizeof(GlyphDrawData) * textLen);
+
+    Vector3 position = node->transform.getPosition();
+
+    // Copy the source text
+    strncpy(this->text, text, textLen + 1);
+    computeString(this->text, font, position, batcher, color, this->drawData);
   }
 
   const char* TextNode::getText() const
@@ -53,5 +148,7 @@ namespace smol
   {
     SMOL_ASSERT(handle->typeIs(SceneNode::Type::TEXT), "Handle passed to TextNode::destroy() is not of type TEXT");
     SystemsRoot::get()->sceneManager.getLoadedScene().destroyNode(handle);
+    handle->sprite.batcher->textNodeCount--;
   }
+
 }

--- a/src/smol_text_node.cpp
+++ b/src/smol_text_node.cpp
@@ -1,0 +1,57 @@
+#include <smol/smol_renderer_types.h>
+#include <smol/smol_text_node.h>
+#include <smol/smol_handle_list.h>
+#include <smol/smol_transform.h>
+#include <smol/smol_systems_root.h>
+#include <smol/smol_scene.h>
+
+namespace smol
+{
+  Handle<SceneNode> TextNode::create(
+      Handle<SpriteBatcher> batcher,
+      Handle<Font> font,
+      const Vector3& position,
+      const char* text,
+      const Color& color,
+      Handle<SceneNode> parent)
+  {
+    Transform t(
+        position,
+        Vector3(0.0f, 0.0f, 0.0f),
+        Vector3(1.0f, 1.0f, 1.0f),
+        parent);
+
+    Scene& scene = SystemsRoot::get()->sceneManager.getLoadedScene();
+    Handle<SceneNode> handle = scene.createNode(SceneNode::Type::TEXT, t);
+    handle->text.batcher = batcher;
+    handle->text.setText(text);
+    batcher->nodeCount++;
+    batcher->dirty = true;
+    handle->text.node = handle;
+    return handle;
+  }
+
+  void TextNode::setText(const char* text)
+  {
+    size_t textLen = strlen(text);
+    size_t memSize = textLen + 1 + textLen * sizeof(VertexPCU);
+    if (arena.getCapacity() == 0)
+    {
+      arena.initialize(memSize);
+    }
+    //arena.reset();
+    //char* memory =  (char*) arena.pushSize(textLen);
+    //...
+  }
+
+  const char* TextNode::getText() const
+  {
+    return text;
+  }
+
+  void TextNode::destroy(Handle<SceneNode> handle)
+  {
+    SMOL_ASSERT(handle->typeIs(SceneNode::Type::TEXT), "Handle passed to TextNode::destroy() is not of type TEXT");
+    SystemsRoot::get()->sceneManager.getLoadedScene().destroyNode(handle);
+  }
+}

--- a/src/smol_transform.cpp
+++ b/src/smol_transform.cpp
@@ -1,5 +1,5 @@
 #include <smol/smol_transform.h>
-#include <smol/smol_scene_nodes.h>
+#include <smol/smol_scene_node.h>
 #include <smol/smol_systems_root.h>
 #include <smol/smol_scene.h>
 


### PR DESCRIPTION
Implements:
- Implements #6 
- Implements #15 

Many organizational changes and improvements:
- Scene nodes are now created via a static create() method on their respective node class.
- Scene nodes are now destroyed via a static destroy() method on their respective node class.
- All creatXXXNode() methods were removed from Scene in favor of the new static create()/destroy() calls on each respective node class.
- It's not possible anymore to create or destroy a node on the game side via scene::createNode() or via scene::destroyNode()
- Added a new renderer level batcher.
- SpriteNode is now drawn using the new batcher.
- Changed Font loading to return a Handle<Font> instead of a raw Font pointer.
- Added a TextNode (not yet functional)
- changed GL version on variables.txt to 3.3 in order to be able to debug with renderDoc.
- remove the concept of a main camera from Scene
- Fix strncpy() calls with wrong length. 
- Change CullFace enumeration values to make it more intuitive on material files
